### PR TITLE
Centralize hit record and bounding box logic in one class

### DIFF
--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/RayProcessor.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/RayProcessor.java
@@ -1,0 +1,665 @@
+package com.github.nhirakawa.hyperbeam;
+
+import static com.github.nhirakawa.hyperbeam.util.MathUtils.rand;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import com.github.nhirakawa.hyperbeam.geometry.Ray;
+import com.github.nhirakawa.hyperbeam.geometry.Vector3;
+import com.github.nhirakawa.hyperbeam.shape.AxisAlignedBoundingBox;
+import com.github.nhirakawa.hyperbeam.shape.BoundingVolumeHierarchyModel;
+import com.github.nhirakawa.hyperbeam.shape.BoxModel;
+import com.github.nhirakawa.hyperbeam.shape.ConstantMediumModel;
+import com.github.nhirakawa.hyperbeam.shape.HitRecord;
+import com.github.nhirakawa.hyperbeam.shape.MovingSphereModel;
+import com.github.nhirakawa.hyperbeam.shape.ReverseNormalsModel;
+import com.github.nhirakawa.hyperbeam.shape.SceneObject;
+import com.github.nhirakawa.hyperbeam.shape.SceneObjectsList;
+import com.github.nhirakawa.hyperbeam.shape.SphereModel;
+import com.github.nhirakawa.hyperbeam.shape.XYRectangleModel;
+import com.github.nhirakawa.hyperbeam.shape.XZRectangleModel;
+import com.github.nhirakawa.hyperbeam.shape.YZRectangleModel;
+import com.github.nhirakawa.hyperbeam.transform.TranslationModel;
+import com.github.nhirakawa.hyperbeam.transform.YRotationModel;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Range;
+import com.google.common.collect.Sets;
+
+public class RayProcessor {
+
+  // hit record
+
+  public Optional<HitRecord> hit(SceneObject sceneObject, Ray ray, double tMin, double tMax) {
+    if (sceneObject instanceof SphereModel) {
+      return hitSphere((SphereModel) sceneObject, ray, tMin, tMax);
+    }
+
+    if (sceneObject instanceof BoundingVolumeHierarchyModel) {
+      return hitBoundingVolumeHierarchy((BoundingVolumeHierarchyModel) sceneObject, ray, tMin, tMax);
+    }
+
+    if (sceneObject instanceof BoxModel) {
+      return hitBox((BoxModel) sceneObject, ray, tMin, tMax);
+    }
+
+    if (sceneObject instanceof SceneObjectsList) {
+      return hitSceneObjectsList((SceneObjectsList) sceneObject, ray, tMin, tMax);
+    }
+
+    if (sceneObject instanceof ConstantMediumModel) {
+      return hitConstantMedium((ConstantMediumModel) sceneObject, ray, tMin, tMax);
+    }
+
+    if (sceneObject instanceof MovingSphereModel) {
+      return hitMovingSphere((MovingSphereModel) sceneObject, ray, tMin, tMax);
+    }
+
+    if (sceneObject instanceof ReverseNormalsModel) {
+      return hitReverseNormals((ReverseNormalsModel) sceneObject, ray, tMin, tMax);
+    }
+
+    if (sceneObject instanceof XYRectangleModel) {
+      return hitXYRectantle((XYRectangleModel) sceneObject, ray, tMin, tMax);
+    }
+
+    if (sceneObject instanceof XZRectangleModel) {
+      return hitXZRectangle((XZRectangleModel) sceneObject, ray, tMin, tMax);
+    }
+
+    if (sceneObject instanceof YZRectangleModel) {
+      return hitYZRectangle((YZRectangleModel) sceneObject, ray, tMin, tMax);
+    }
+
+    if (sceneObject instanceof TranslationModel) {
+      return hitTranslation((TranslationModel) sceneObject, ray, tMin, tMax);
+    }
+
+    if (sceneObject instanceof YRotationModel) {
+      return hitYRotation((YRotationModel) sceneObject, ray, tMin, tMax);
+    }
+
+    throw new IllegalArgumentException("Can't hit unknown object - " + sceneObject);
+  }
+
+  private Optional<HitRecord> hitSphere(SphereModel sphere, Ray ray, double tMin, double tMax) {
+    Vector3 oc = ray.getOrigin().subtract(sphere.getCenter());
+
+    double a = ray.getDirection().dotProduct(ray.getDirection());
+    double b = oc.dotProduct(ray.getDirection());
+    double c = oc.dotProduct(oc) - (sphere.getRadius() * sphere.getRadius());
+
+    double discriminant = (b * b) - (a * c);
+
+    if (discriminant > 0) {
+      double negativeTemp = (-b - Math.sqrt(discriminant)) / a; // TODO rename this awful variable
+      Range<Double> parameterRange = Range.open(tMin, tMax);
+
+      if (parameterRange.contains(negativeTemp)) {
+        Vector3 point = ray.getPointAtParameter(negativeTemp);
+        Vector3 normal = point.subtract(sphere.getCenter()).scalarDivide(sphere.getRadius());
+
+        Vector3 uvPoint = point.subtract(sphere.getCenter());
+
+        double phi = Math.atan2(uvPoint.getZ(), uvPoint.getX());
+        double theta = Math.asin(uvPoint.getY());
+
+        double u = (1 - phi + Math.PI) / (2 * Math.PI);
+        double v = (theta + (Math.PI / 2)) / Math.PI;
+
+        return Optional.of(
+            HitRecord.builder()
+                .setT(negativeTemp)
+                .setPoint(point)
+                .setNormal(normal)
+                .setMaterial(sphere.getMaterial())
+                .setU(u)
+                .setV(v)
+                .build()
+        );
+      }
+
+      double positiveTemp = (-b + Math.sqrt(discriminant)) / a; // TODO rename this awful variable
+      if (parameterRange.contains(positiveTemp)) {
+        Vector3 point = ray.getPointAtParameter(positiveTemp);
+        Vector3 normal = point.subtract(sphere.getCenter()).scalarDivide(sphere.getRadius());
+
+        Vector3 uvPpoint = point.subtract(sphere.getCenter());
+
+        double phi = Math.atan2(uvPpoint.getZ(), uvPpoint.getX());
+        double theta = Math.asin(uvPpoint.getY());
+
+        double u = (1 - phi + Math.PI) / (2 * Math.PI);
+        double v = (theta + (Math.PI / 2)) / Math.PI;
+
+        return Optional.of(
+            HitRecord.builder()
+                .setT(positiveTemp)
+                .setPoint(point)
+                .setNormal(normal)
+                .setMaterial(sphere.getMaterial())
+                .setU(u)
+                .setV(v)
+                .build()
+        );
+      }
+    }
+
+    return Optional.empty();
+  }
+
+  private Optional<HitRecord> hitBoundingVolumeHierarchy(BoundingVolumeHierarchyModel boundingVolumeHierarchy, Ray ray, double tMin, double tMax) {
+    if (getAxisAlignedBoundingBoxForBoundingVolumeHierarchy(boundingVolumeHierarchy).hit(ray, tMin, tMax)) {
+      Optional<HitRecord> leftHitRecord = hit(boundingVolumeHierarchy.getLeft(), ray, tMin, tMax);
+      Optional<HitRecord> rightHitRecord = hit(boundingVolumeHierarchy.getRight(), ray, tMin, tMax);
+
+      if (leftHitRecord.isPresent() && rightHitRecord.isPresent()) {
+        if (leftHitRecord.get().getT() < rightHitRecord.get().getT()) {
+          return leftHitRecord;
+        } else {
+          return rightHitRecord;
+        }
+      } else if (leftHitRecord.isPresent()) {
+        return leftHitRecord;
+      } else if (rightHitRecord.isPresent()) {
+        return rightHitRecord;
+      } else {
+        return Optional.empty();
+      }
+    } else {
+      return Optional.empty();
+    }
+  }
+
+  private Optional<HitRecord> hitBox(BoxModel box, Ray ray, double tMin, double tMax) {
+    return hit(box.getSceneObjectsList(), ray, tMin, tMax);
+  }
+
+  private Optional<HitRecord> hitSceneObjectsList(SceneObjectsList sceneObjectsList, Ray ray, double tMin, double tMax) {
+    Optional<HitRecord> tempRecord = Optional.empty();
+    double closestSoFar = tMax;
+
+    for (int i = 0; i < sceneObjectsList.getHittables().size(); i++) {
+      Optional<HitRecord> maybeHitRecord = hit(sceneObjectsList.getHittables().get(i), ray, tMin, closestSoFar);
+      if (maybeHitRecord.isPresent()) {
+        tempRecord = maybeHitRecord;
+        closestSoFar = maybeHitRecord.get().getT();
+      }
+    }
+
+    return tempRecord;
+  }
+
+  private Optional<HitRecord> hitConstantMedium(ConstantMediumModel constantMedium, Ray ray, double tMin, double tMax) {
+    Optional<HitRecord> hitRecord1 = hit(constantMedium.getSceneObject(), ray, -Double.MAX_VALUE, Double.MAX_VALUE);
+    if (!hitRecord1.isPresent()) {
+      return Optional.empty();
+    }
+
+    Optional<HitRecord> hitRecord2 = hit(constantMedium.getSceneObject(), ray, hitRecord1.get().getT() + 0.0001, Double.MAX_VALUE);
+    if (!hitRecord2.isPresent()) {
+      return Optional.empty();
+    }
+
+    double hitRecord1MaxT = hitRecord1.get().getT();
+    if (hitRecord1MaxT < tMin) {
+      hitRecord1MaxT = tMin;
+    }
+
+    double hitRecord2MinT = hitRecord2.get().getT();
+    if (hitRecord2MinT > tMax) {
+      hitRecord2MinT = tMax;
+    }
+
+    if (hitRecord1MaxT >= hitRecord2MinT) {
+      return Optional.empty();
+    }
+
+    if (hitRecord1MaxT < 0) {
+      hitRecord1MaxT = 0;
+    }
+
+    double distanceInsideBoundary = (hitRecord2MinT - hitRecord1MaxT) * ray.getDirection().getNorm();
+    double hitDistance = (-1 / constantMedium.getDensity()) * Math.log(rand());
+
+    if (hitDistance >= distanceInsideBoundary) {
+      return Optional.empty();
+    }
+
+    double t = hitRecord1MaxT + (hitDistance / ray.getDirection().getNorm());
+    Vector3 point = ray.getPointAtParameter(t);
+
+    return Optional.of(
+        HitRecord.builder()
+            .setPoint(point)
+            .setMaterial(constantMedium.getPhaseFunction())
+            .setNormal(ConstantMediumModel.normal())
+            .setT(t)
+            .build()
+    );
+  }
+
+  private Optional<HitRecord> hitMovingSphere(MovingSphereModel movingSphere, Ray ray, double tMin, double tMax) {
+    Vector3 center = movingSphere.getCenter(ray.getTime());
+    Vector3 oc = ray.getOrigin().subtract(center);
+
+    double a = ray.getDirection().dotProduct(ray.getDirection());
+    double b = oc.dotProduct(ray.getDirection());
+    double c = oc.dotProduct(oc) - (movingSphere.getRadius() * movingSphere.getRadius());
+
+    double discriminant = (b * b) - (a * c);
+
+    if (discriminant > 0) {
+      double negativeTemp = (-b - Math.sqrt(discriminant)) / a; // TODO rename this awful variable
+      Range<Double> parameterRange = Range.open(tMin, tMax);
+
+      if (parameterRange.contains(negativeTemp)) {
+        Vector3 point = ray.getPointAtParameter(negativeTemp);
+        Vector3 normal = point.subtract(center).scalarDivide(movingSphere.getRadius());
+        return Optional.of(
+            HitRecord.builder()
+                .setT(negativeTemp)
+                .setPoint(point)
+                .setNormal(normal)
+                .setMaterial(movingSphere.getMaterial())
+                .build()
+        );
+      }
+
+      double positiveTemp = (-b + Math.sqrt(discriminant)) / a; // TODO rename this awful variable
+      if (parameterRange.contains(positiveTemp)) {
+        Vector3 point = ray.getPointAtParameter(positiveTemp);
+        Vector3 normal = point.subtract(center).scalarDivide(movingSphere.getRadius());
+        return Optional.of(
+            HitRecord.builder()
+                .setT(positiveTemp)
+                .setPoint(point)
+                .setNormal(normal)
+                .setMaterial(movingSphere.getMaterial())
+                .build()
+        );
+      }
+    }
+
+    return Optional.empty();
+  }
+
+  private Optional<HitRecord> hitReverseNormals(ReverseNormalsModel reverseNormals, Ray ray, double tMin, double tMax) {
+    return hit(reverseNormals.getSceneObject(), ray, tMin, tMax)
+        .map(hitRecord -> hitRecord.withNormal(hitRecord.getNormal().negate()));
+  }
+
+  private Optional<HitRecord> hitXYRectantle(XYRectangleModel xyRectangle, Ray ray, double tMin, double tMax) {
+    double t = (xyRectangle.getK() - ray.getOrigin().getZ()) / ray.getDirection().getZ();
+
+    if (t < tMin || t > tMax) {
+      return Optional.empty();
+    }
+
+    double x = ray.getOrigin().getX() + (ray.getDirection().getX() * t);
+    double y = ray.getOrigin().getY() + (ray.getDirection().getY() * t);
+
+    if (x < xyRectangle.getX0() || x > xyRectangle.getX1() || y < xyRectangle.getY0() || y > xyRectangle.getY1()) {
+      return Optional.empty();
+    }
+
+    double u = (x - xyRectangle.getX0()) / (xyRectangle.getX1() - xyRectangle.getX0());
+    double v = (y - xyRectangle.getY0()) / (xyRectangle.getY1() - xyRectangle.getY0());
+
+    Vector3 normal = Vector3.builder()
+        .setX(0)
+        .setY(0)
+        .setZ(1)
+        .build();
+
+    return Optional.of(
+        HitRecord.builder()
+            .setPoint(ray.getPointAtParameter(t))
+            .setNormal(normal)
+            .setMaterial(xyRectangle.getMaterial())
+            .setT(t)
+            .setU(u)
+            .setV(v)
+            .build()
+    );
+  }
+
+  private Optional<HitRecord> hitXZRectangle(XZRectangleModel xzRectangle, Ray ray, double tMin, double tMax) {
+    double t = (xzRectangle.getK() - ray.getOrigin().getY()) / ray.getDirection().getY();
+
+    if (t < tMin || t > tMax) {
+      return Optional.empty();
+    }
+
+    double x = ray.getOrigin().getX() + (t * ray.getDirection().getX());
+    double z = ray.getOrigin().getZ() + (t * ray.getDirection().getZ());
+
+    if (x < xzRectangle.getX0() || x > xzRectangle.getX1() || z < xzRectangle.getZ0() || z > xzRectangle.getZ1()) {
+      return Optional.empty();
+    }
+
+    double u = (x - xzRectangle.getX0()) / (xzRectangle.getX1() - xzRectangle.getX0());
+    double v = (z - xzRectangle.getZ0()) / (xzRectangle.getZ1() - xzRectangle.getZ0());
+
+    return Optional.of(
+        HitRecord.builder()
+            .setPoint(ray.getPointAtParameter(t))
+            .setT(t)
+            .setU(u)
+            .setV(v)
+            .setNormal(xzRectangle.getNormal())
+            .setMaterial(xzRectangle.getMaterial())
+            .build()
+    );
+  }
+
+  private Optional<HitRecord> hitYZRectangle(YZRectangleModel yzRectangle, Ray ray, double tMin, double tMax) {
+    double t = (yzRectangle.getK() - ray.getOrigin().getX()) / ray.getDirection().getX();
+
+    if (t < tMin || t > tMax) {
+      return Optional.empty();
+    }
+
+    double y = ray.getOrigin().getY() + (t * ray.getDirection().getY());
+    double z = ray.getOrigin().getZ() + (t * ray.getDirection().getZ());
+
+    if (y < yzRectangle.getY0() || y > yzRectangle.getY1() || z < yzRectangle.getZ0() || z > yzRectangle.getZ1()) {
+      return Optional.empty();
+    }
+
+    double u = (y - yzRectangle.getY0()) / (yzRectangle.getY1() - yzRectangle.getY0());
+    double v = (z - yzRectangle.getZ0()) / (yzRectangle.getZ1() - yzRectangle.getZ0());
+
+    return Optional.of(
+        HitRecord.builder()
+            .setPoint(ray.getPointAtParameter(t))
+            .setMaterial(yzRectangle.getMaterial())
+            .setT(t)
+            .setU(u)
+            .setV(v)
+            .setNormal(yzRectangle.getNormal())
+            .build()
+    );
+  }
+
+  private Optional<HitRecord> hitTranslation(TranslationModel translation, Ray ray, double tMin, double tMax) {
+    Ray offsetRay = ray.withOrigin(ray.getOrigin().subtract(translation.getOffset()));
+
+    return hit(translation.getSceneObject(), offsetRay, tMin, tMax)
+        .map(hitRecord -> hitRecord.withPoint(hitRecord.getPoint().add(translation.getOffset())));
+  }
+
+  private Optional<HitRecord> hitYRotation(YRotationModel yRotation, Ray ray, double tMin, double tMax) {
+    Vector3 origin = ray.getOrigin();
+    Vector3 direction = ray.getDirection();
+
+    double newOriginX = (yRotation.getCosTheta() * origin.getX()) - (yRotation.getSinTheta() * origin.getZ());
+    double newOriginZ = (yRotation.getSinTheta() * origin.getX()) + (yRotation.getCosTheta() * origin.getZ());
+
+    double newDirectionX = (yRotation.getCosTheta() * direction.getX()) - (yRotation.getSinTheta() * direction.getZ());
+    double newDirectionZ = (yRotation.getSinTheta() * direction.getX()) + (yRotation.getCosTheta() * direction.getZ());
+
+    Vector3 newOrigin = Vector3.builder()
+        .setX(newOriginX)
+        .setY(origin.getY())
+        .setZ(newOriginZ)
+        .build();
+
+    Vector3 newDirection = Vector3.builder()
+        .setX(newDirectionX)
+        .setY(direction.getY())
+        .setZ(newDirectionZ)
+        .build();
+
+    Ray rotatedRay = Ray.builder()
+        .from(ray)
+        .setOrigin(newOrigin)
+        .setDirection(newDirection)
+        .build();
+
+    Optional<HitRecord> maybeHitRecord = hit(yRotation.getSceneObject(), rotatedRay, tMin, tMax);
+    if (!maybeHitRecord.isPresent()) {
+      return Optional.empty();
+    }
+
+    HitRecord hitRecord = maybeHitRecord.get();
+    Vector3 point = hitRecord.getPoint();
+    Vector3 normal = hitRecord.getNormal();
+
+    double newPointX = (yRotation.getCosTheta() * point.getX()) + (yRotation.getSinTheta() * point.getZ());
+    double newPointZ = (yRotation.getCosTheta() * point.getZ()) - (yRotation.getSinTheta() * point.getX());
+
+    double newNormalX = (yRotation.getCosTheta() * normal.getX()) + (yRotation.getSinTheta() * normal.getZ());
+    double newNormalZ = (yRotation.getCosTheta() * normal.getZ()) - (yRotation.getSinTheta() * normal.getZ());
+
+    Vector3 newPoint = Vector3.builder()
+        .setX(newPointX)
+        .setY(point.getY())
+        .setZ(newPointZ)
+        .build();
+
+    Vector3 newNormal = Vector3.builder()
+        .setX(newNormalX)
+        .setY(normal.getY())
+        .setZ(newNormalZ)
+        .build();
+
+    return Optional.of(
+        HitRecord.builder()
+            .from(hitRecord)
+            .setPoint(newPoint)
+            .setNormal(newNormal)
+            .build()
+    );
+  }
+
+  // bounding box
+
+  public Optional<AxisAlignedBoundingBox> getBoundingBox(SceneObject sceneObject, double t0, double t1) {
+    if (sceneObject instanceof BoundingVolumeHierarchyModel) {
+      return getBoundingBoxForBoundingVolumeHierarcy((BoundingVolumeHierarchyModel) sceneObject, t0, t1);
+    }
+
+    if (sceneObject instanceof BoxModel) {
+      return getBoundingBoxForBox((BoxModel) sceneObject, t0, t1);
+    }
+
+    if (sceneObject instanceof ConstantMediumModel) {
+      return getBoundingBoxForConstantMedium((ConstantMediumModel) sceneObject, t0, t1);
+    }
+
+    if (sceneObject instanceof MovingSphereModel) {
+      return getBoundingBoxForMovingSphere((MovingSphereModel) sceneObject, t0, t1);
+    }
+
+    if (sceneObject instanceof ReverseNormalsModel) {
+      return getBoundingBoxForReverseNormals((ReverseNormalsModel) sceneObject, t0, t1);
+    }
+
+    if (sceneObject instanceof SceneObjectsList) {
+      return getBoundingBoxForSceneObjectsList((SceneObjectsList) sceneObject, t0, t1);
+    }
+
+    if (sceneObject instanceof SphereModel) {
+      return getBoundingBoxForSphere((SphereModel) sceneObject, t0, t1);
+    }
+
+    if (sceneObject instanceof XYRectangleModel) {
+      return getBoundingBoxForXYRectangle((XYRectangleModel) sceneObject, t0, t1);
+    }
+
+    if (sceneObject instanceof XZRectangleModel) {
+      return getBoundingBoxForXZRectangle((XZRectangleModel) sceneObject, t0, t1);
+    }
+
+    if (sceneObject instanceof YZRectangleModel) {
+      return getBoundingBoxForYZRectangle((YZRectangleModel) sceneObject, t0, t1);
+    }
+
+    if (sceneObject instanceof TranslationModel) {
+      return getBoundingBoxForTranslation((TranslationModel) sceneObject, t0, t1);
+    }
+
+    if (sceneObject instanceof YRotationModel) {
+      return getBoundingBoxForYRotation((YRotationModel) sceneObject, t0, t1);
+    }
+
+    throw new IllegalArgumentException("Cannot get bounding box for " + sceneObject);
+  }
+
+  private Optional<AxisAlignedBoundingBox> getBoundingBoxForBoundingVolumeHierarcy(BoundingVolumeHierarchyModel boundingVolumeHierarchy, double t0, double t1) {
+    return Optional.of(getAxisAlignedBoundingBoxForBoundingVolumeHierarchy(boundingVolumeHierarchy));
+  }
+
+  private AxisAlignedBoundingBox getAxisAlignedBoundingBoxForBoundingVolumeHierarchy(BoundingVolumeHierarchyModel boundingVolumeHierarchy) {
+    Optional<AxisAlignedBoundingBox> leftBox =getBoundingBox(boundingVolumeHierarchy.getLeft(), boundingVolumeHierarchy.getTime0(), boundingVolumeHierarchy.getTime1());
+    Optional<AxisAlignedBoundingBox> rightBox = getBoundingBox(boundingVolumeHierarchy.getRight(), boundingVolumeHierarchy.getTime0(), boundingVolumeHierarchy.getTime1());
+
+    Preconditions.checkState(leftBox.isPresent(), "Could not get bounding box for %s", boundingVolumeHierarchy.getLeft());
+    Preconditions.checkState(rightBox.isPresent(), "Could not get bounding box for %s", boundingVolumeHierarchy.getRight());
+
+    return AxisAlignedBoundingBox.getSurroundingBox(leftBox.get(), rightBox.get());
+  }
+
+  private Optional<AxisAlignedBoundingBox> getBoundingBoxForBox(BoxModel box, double t0, double t1) {
+    return Optional.of(box.getBoundingBox());
+  }
+
+  private Optional<AxisAlignedBoundingBox> getBoundingBoxForConstantMedium(ConstantMediumModel constantMedium, double t0, double t1) {
+    return getBoundingBox(constantMedium.getSceneObject(), t0, t1);
+  }
+
+  private Optional<AxisAlignedBoundingBox> getBoundingBoxForMovingSphere(MovingSphereModel movingSphere, double t0, double t1) {
+    Vector3 radiusVector = Vector3.builder()
+        .setX(movingSphere.getRadius())
+        .setY(movingSphere.getRadius())
+        .setZ(movingSphere.getRadius())
+        .build();
+
+    AxisAlignedBoundingBox box0 = AxisAlignedBoundingBox.builder()
+        .setMin(movingSphere.getCenter(t0).subtract(radiusVector))
+        .setMax(movingSphere.getCenter(t0).add(radiusVector))
+        .build();
+    AxisAlignedBoundingBox box1 = AxisAlignedBoundingBox.builder()
+        .setMin(movingSphere.getCenter(t1).subtract(radiusVector))
+        .setMax(movingSphere.getCenter(t1).add(radiusVector))
+        .build();
+
+    return Optional.of(AxisAlignedBoundingBox.getSurroundingBox(box0, box1));
+  }
+
+  private Optional<AxisAlignedBoundingBox> getBoundingBoxForReverseNormals(ReverseNormalsModel reverseNormals, double t0, double t1) {
+    return getBoundingBox(reverseNormals.getSceneObject(), t0, t1);
+  }
+
+  private Optional<AxisAlignedBoundingBox> getBoundingBoxForSceneObjectsList(SceneObjectsList sceneObjectsList, double t0, double t1) {
+    if (sceneObjectsList.getHittables().isEmpty()) {
+      return Optional.empty();
+    }
+
+    Optional<AxisAlignedBoundingBox> current = getBoundingBox(sceneObjectsList.getHittables().get(0), t0, t1);
+    if (!current.isPresent()) {
+      return Optional.empty();
+    }
+
+    for (int i = 0; i < sceneObjectsList.getHittables().size(); i++) {
+      Optional<AxisAlignedBoundingBox> temp = getBoundingBox(sceneObjectsList.getHittables().get(i), t0, t1);
+      if (!temp.isPresent()) {
+        return Optional.empty();
+      }
+
+      current = Optional.of(AxisAlignedBoundingBox.getSurroundingBox(current.get(), temp.get()));
+    }
+
+    return current;
+  }
+
+  private Optional<AxisAlignedBoundingBox> getBoundingBoxForSphere(SphereModel sphere, double t0, double t1) {
+    return Optional.of(sphere.getAxisAlignedBoundingBox());
+  }
+
+  private Optional<AxisAlignedBoundingBox> getBoundingBoxForXYRectangle(XYRectangleModel xyRectangle, double t0, double t1) {
+    return xyRectangle.getBoundingBox();
+  }
+
+  private Optional<AxisAlignedBoundingBox> getBoundingBoxForXZRectangle(XZRectangleModel xzRectangle, double t0, double t1) {
+    return Optional.of(xzRectangle.getBoundingBox());
+  }
+
+  private Optional<AxisAlignedBoundingBox> getBoundingBoxForYZRectangle(YZRectangleModel yzRectangle, double t0, double t1) {
+    return Optional.of(yzRectangle.getBoundingBox());
+  }
+
+  private Optional<AxisAlignedBoundingBox> getBoundingBoxForTranslation(TranslationModel translation, double t0, double t1) {
+    return getBoundingBox(translation.getSceneObject(), t0, t1)
+        .map(translation::getOffsetAxisAlignedBoundingBox);
+  }
+
+  private Optional<AxisAlignedBoundingBox> getBoundingBoxForYRotation(YRotationModel yRotation, double t0, double t1) {
+    Optional<AxisAlignedBoundingBox> maybeBoundingBox = getBoundingBox(yRotation.getSceneObject(), 0, 1);
+    if (!maybeBoundingBox.isPresent()) {
+      return Optional.empty();
+    }
+
+    AxisAlignedBoundingBox boundingBox = maybeBoundingBox.get();
+
+    Vector3 min = Vector3.max();
+    Vector3 max = Vector3.min();
+
+    Set<Integer> integers = ImmutableSet.of(0, 1);
+    Set<List<Integer>> products = Sets.cartesianProduct(integers, integers, integers);
+
+    for (List<Integer> product : products) {
+      Preconditions.checkState(product.size() == 3);
+
+      int i = product.get(0);
+      int j = product.get(1);
+      int k = product.get(2);
+
+      double x = (i * boundingBox.getMax().getX()) + ((1 - i) * boundingBox.getMin().getX());
+      double y = (j * boundingBox.getMax().getY()) + ((1 - j) * boundingBox.getMin().getY());
+      double z = (k * boundingBox.getMax().getZ()) + ((1 - k) * boundingBox.getMin().getZ());
+
+      double newX = (yRotation.getCosTheta() * x) + (yRotation.getSinTheta() * z);
+      double newZ = (yRotation.getCosTheta() * z) - (yRotation.getSinTheta() * x);
+
+      Vector3 tester = Vector3.builder()
+          .setX(newX)
+          .setY(y)
+          .setZ(newZ)
+          .build();
+
+      double maxX = Math.max(tester.getX(), max.getX());
+      double maxY = Math.max(tester.getY(), max.getY());
+      double maxZ = Math.max(tester.getZ(), max.getZ());
+
+      max = Vector3.builder()
+          .setX(maxX)
+          .setY(maxY)
+          .setZ(maxZ)
+          .build();
+
+      double minX = Math.min(tester.getX(), min.getX());
+      double minY = Math.min(tester.getY(), min.getY());
+      double minZ = Math.min(tester.getZ(), min.getZ());
+
+      min = Vector3.builder()
+          .setX(minX)
+          .setY(minY)
+          .setZ(minZ)
+          .build();
+    }
+
+    return Optional.of(
+        AxisAlignedBoundingBox.builder()
+            .setMin(min)
+            .setMax(max)
+            .build()
+    );
+  }
+
+}
+
+

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/SortedHittablesFactory.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/SortedHittablesFactory.java
@@ -1,0 +1,61 @@
+package com.github.nhirakawa.hyperbeam;
+
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+
+import com.github.nhirakawa.hyperbeam.shape.AxisAlignedBoundingBox;
+import com.github.nhirakawa.hyperbeam.shape.SceneObject;
+import com.github.nhirakawa.hyperbeam.util.MathUtils;
+import com.google.common.collect.ImmutableList;
+
+public class SortedHittablesFactory {
+
+  private final RayProcessor rayProcessor;
+
+  public SortedHittablesFactory(RayProcessor rayProcessor) {
+    this.rayProcessor = rayProcessor;
+  }
+
+  private static final Function<AxisAlignedBoundingBox, Double> MIN_X = aabb -> aabb.getMin().getX();
+  private static final Function<AxisAlignedBoundingBox, Double> MIN_Y = aabb -> aabb.getMin().getY();
+  private static final Function<AxisAlignedBoundingBox, Double> MIN_Z = aabb -> aabb.getMin().getZ();
+
+  List<SceneObject> getSortedHittables(Collection<SceneObject> sceneObjects) {
+    final Comparator<SceneObject> comparator;
+    switch ((int) (MathUtils.rand() * 3)) {
+      case 0:
+        comparator = getComparator(MIN_X);
+        break;
+      case 1:
+        comparator = getComparator(MIN_Y);
+        break;
+      case 2:
+        comparator = getComparator(MIN_Z);
+        break;
+      default:
+        throw new IllegalArgumentException("Invalid random number when sorting hittables");
+    }
+
+    return sceneObjects.stream()
+        .sorted(comparator)
+        .collect(ImmutableList.toImmutableList());
+  }
+
+  private Comparator<SceneObject> getComparator(Function<AxisAlignedBoundingBox, Double> function) {
+    return (hittable1, hittable2) -> {
+      Optional<AxisAlignedBoundingBox> box1 = rayProcessor.getBoundingBox(hittable1, 0, 0);
+      Optional<AxisAlignedBoundingBox> box2 = rayProcessor.getBoundingBox(hittable2, 0, 0);
+
+      if (function.apply(box1.get()) - function.apply(box2.get()) < 0) {
+        return -1;
+      } else {
+        return 1;
+      }
+    };
+  }
+
+
+}

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/BoundingVolumeHierarchyModel.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/BoundingVolumeHierarchyModel.java
@@ -1,28 +1,17 @@
 package com.github.nhirakawa.hyperbeam.shape;
 
-import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
-import java.util.function.Function;
 
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.github.nhirakawa.hyperbeam.geometry.Ray;
 import com.github.nhirakawa.immutable.style.ImmutableStyle;
-import com.github.nhirakawa.hyperbeam.util.MathUtils;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 
 @Value.Immutable
 @ImmutableStyle
 public abstract class BoundingVolumeHierarchyModel implements SceneObject {
 
-  private static final Function<AxisAlignedBoundingBox, Double> MIN_X = aabb -> aabb.getMin().getX();
-  private static final Function<AxisAlignedBoundingBox, Double> MIN_Y = aabb -> aabb.getMin().getY();
-  private static final Function<AxisAlignedBoundingBox, Double> MIN_Z = aabb -> aabb.getMin().getZ();
-
-  public abstract SceneObjectsList getSceneObjectsList();
+  public abstract List<SceneObject> getSortedSceneObjects();
   public abstract double getTime0();
   public abstract double getTime1();
 
@@ -34,31 +23,8 @@ public abstract class BoundingVolumeHierarchyModel implements SceneObject {
 
   @Value.Lazy
   @JsonIgnore
-  public List<SceneObject> getSortedHittablesList() {
-    final Comparator<SceneObject> comparator;
-    switch ((int) (MathUtils.rand() * 3)) {
-      case 0:
-        comparator = getComparator(MIN_X);
-        break;
-      case 1:
-        comparator = getComparator(MIN_Y);
-        break;
-      case 2:
-        comparator = getComparator(MIN_Z);
-        break;
-      default:
-        throw new IllegalArgumentException("Invalid random number when sorting hittables");
-    }
-
-    return getSceneObjectsList().getHittables().stream()
-        .sorted(comparator)
-        .collect(ImmutableList.toImmutableList());
-  }
-
-  @Value.Lazy
-  @JsonIgnore
   public SceneObject getLeft() {
-    List<SceneObject> sortedHittablesList = getSortedHittablesList();
+    List<SceneObject> sortedHittablesList = getSortedSceneObjects();
     int size = sortedHittablesList.size();
 
     if (size == 1) {
@@ -67,7 +33,7 @@ public abstract class BoundingVolumeHierarchyModel implements SceneObject {
       return sortedHittablesList.get(0);
     } else {
       return BoundingVolumeHierarchy.builder()
-          .setSceneObjectsList(new SceneObjectsList(sortedHittablesList.subList(0, size / 2)))
+          .setSortedSceneObjects(sortedHittablesList.subList(0, size / 2))
           .setTime0(getTime0())
           .setTime1(getTime1())
           .build();
@@ -77,7 +43,7 @@ public abstract class BoundingVolumeHierarchyModel implements SceneObject {
   @Value.Lazy
   @JsonIgnore
   public SceneObject getRight() {
-    List<SceneObject> sortedHittablesList = getSortedHittablesList();
+    List<SceneObject> sortedHittablesList = getSortedSceneObjects();
     int size = sortedHittablesList.size();
 
     if (size == 1) {
@@ -86,65 +52,11 @@ public abstract class BoundingVolumeHierarchyModel implements SceneObject {
       return sortedHittablesList.get(1);
     } else {
       return BoundingVolumeHierarchy.builder()
-          .setSceneObjectsList(new SceneObjectsList(sortedHittablesList.subList(size / 2, size)))
+          .setSortedSceneObjects(sortedHittablesList.subList(size / 2, size))
           .setTime0(getTime0())
           .setTime1(getTime1())
           .build();
     }
-  }
-
-  @Value.Lazy
-  @JsonIgnore
-  public AxisAlignedBoundingBox getAxisAlignedBoundingBox() {
-    Optional<AxisAlignedBoundingBox> leftBox = getLeft().getBoundingBox(getTime0(), getTime1());
-    Optional<AxisAlignedBoundingBox> rightBox = getRight().getBoundingBox(getTime0(), getTime1());
-
-    Preconditions.checkState(leftBox.isPresent(), "Could not get bounding box for %s", getLeft());
-    Preconditions.checkState(rightBox.isPresent(), "Could not get bounding box for %s", getRight());
-
-    return AxisAlignedBoundingBox.getSurroundingBox(leftBox.get(), rightBox.get());
-  }
-
-  @Override
-  public Optional<HitRecord> hit(Ray ray, double tMin, double tMax) {
-    if (getAxisAlignedBoundingBox().hit(ray, tMin, tMax)) {
-      Optional<HitRecord> leftHitRecord = getLeft().hit(ray, tMin, tMax);
-      Optional<HitRecord> rightHitRecord = getRight().hit(ray, tMin, tMax);
-
-      if (leftHitRecord.isPresent() && rightHitRecord.isPresent()) {
-        if (leftHitRecord.get().getT() < rightHitRecord.get().getT()) {
-          return leftHitRecord;
-        } else {
-          return rightHitRecord;
-        }
-      } else if (leftHitRecord.isPresent()) {
-        return leftHitRecord;
-      } else if (rightHitRecord.isPresent()) {
-        return rightHitRecord;
-      } else {
-        return Optional.empty();
-      }
-    } else {
-      return Optional.empty();
-    }
-  }
-
-  @Override
-  public Optional<AxisAlignedBoundingBox> getBoundingBox(double t0, double t1) {
-    return Optional.of(getAxisAlignedBoundingBox());
-  }
-
-  private static Comparator<SceneObject> getComparator(Function<AxisAlignedBoundingBox, Double> function) {
-    return (hittable1, hittable2) -> {
-      Optional<AxisAlignedBoundingBox> box1 = hittable1.getBoundingBox(0, 0);
-      Optional<AxisAlignedBoundingBox> box2 = hittable2.getBoundingBox(0, 0);
-
-      if (function.apply(box1.get()) - function.apply(box2.get()) < 0) {
-        return -1;
-      } else {
-        return 1;
-      }
-    };
   }
 
 }

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/BoxModel.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/BoxModel.java
@@ -1,11 +1,8 @@
 package com.github.nhirakawa.hyperbeam.shape;
 
-import java.util.Optional;
-
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.github.nhirakawa.hyperbeam.geometry.Ray;
 import com.github.nhirakawa.hyperbeam.geometry.Vector3;
 import com.github.nhirakawa.hyperbeam.material.Material;
 import com.github.nhirakawa.immutable.style.ImmutableStyle;
@@ -95,16 +92,6 @@ public abstract class BoxModel implements SceneObject {
         .setMin(getPMin())
         .setMax(getPMax())
         .build();
-  }
-
-  @Override
-  public Optional<HitRecord> hit(Ray ray, double tMin, double tMax) {
-    return getSceneObjectsList().hit(ray, tMin, tMax);
-  }
-
-  @Override
-  public Optional<AxisAlignedBoundingBox> getBoundingBox(double t0, double t1) {
-    return Optional.of(getBoundingBox());
   }
 
   @Override

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/ConstantMediumModel.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/ConstantMediumModel.java
@@ -1,13 +1,8 @@
 package com.github.nhirakawa.hyperbeam.shape;
 
-import static com.github.nhirakawa.hyperbeam.util.MathUtils.rand;
-
-import java.util.Optional;
-
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.github.nhirakawa.hyperbeam.geometry.Ray;
 import com.github.nhirakawa.hyperbeam.geometry.Vector3;
 import com.github.nhirakawa.hyperbeam.material.IsotropicMaterial;
 import com.github.nhirakawa.hyperbeam.material.Material;
@@ -36,64 +31,14 @@ public abstract class ConstantMediumModel implements SceneObject {
         .build();
   }
 
+  @JsonIgnore
+  public static Vector3 normal() {
+    return NORMAL;
+  }
+
   @Override
   public SceneObjectType getShapeType() {
     return SceneObjectType.CONSTANT_MEDIUM;
-  }
-
-  @Override
-  public Optional<HitRecord> hit(Ray ray, double tMin, double tMax) {
-    Optional<HitRecord> hitRecord1 = getSceneObject().hit(ray, -Double.MAX_VALUE, Double.MAX_VALUE);
-    if (!hitRecord1.isPresent()) {
-      return Optional.empty();
-    }
-
-    Optional<HitRecord> hitRecord2 = getSceneObject().hit(ray, hitRecord1.get().getT() + 0.0001, Double.MAX_VALUE);
-    if (!hitRecord2.isPresent()) {
-      return Optional.empty();
-    }
-
-    double hitRecord1MaxT = hitRecord1.get().getT();
-    if (hitRecord1MaxT < tMin) {
-      hitRecord1MaxT = tMin;
-    }
-
-    double hitRecord2MinT = hitRecord2.get().getT();
-    if (hitRecord2MinT > tMax) {
-      hitRecord2MinT = tMax;
-    }
-
-    if (hitRecord1MaxT >= hitRecord2MinT) {
-      return Optional.empty();
-    }
-
-    if (hitRecord1MaxT < 0) {
-      hitRecord1MaxT = 0;
-    }
-
-    double distanceInsideBoundary = (hitRecord2MinT - hitRecord1MaxT) * ray.getDirection().getNorm();
-    double hitDistance = (-1 / getDensity()) * Math.log(rand());
-
-    if (hitDistance >= distanceInsideBoundary) {
-      return Optional.empty();
-    }
-
-    double t = hitRecord1MaxT + (hitDistance / ray.getDirection().getNorm());
-    Vector3 point = ray.getPointAtParameter(t);
-
-    return Optional.of(
-        HitRecord.builder()
-            .setPoint(point)
-            .setMaterial(getPhaseFunction())
-            .setNormal(NORMAL)
-            .setT(t)
-            .build()
-    );
-  }
-
-  @Override
-  public Optional<AxisAlignedBoundingBox> getBoundingBox(double t0, double t1) {
-    return getSceneObject().getBoundingBox(t0, t1);
   }
 
 }

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/MovingSphereModel.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/MovingSphereModel.java
@@ -1,14 +1,10 @@
 package com.github.nhirakawa.hyperbeam.shape;
 
-import java.util.Optional;
-
 import org.immutables.value.Value;
 
-import com.github.nhirakawa.hyperbeam.geometry.Ray;
 import com.github.nhirakawa.hyperbeam.geometry.Vector3;
 import com.github.nhirakawa.hyperbeam.material.Material;
 import com.github.nhirakawa.immutable.style.ImmutableStyle;
-import com.google.common.collect.Range;
 
 @Value.Immutable
 @ImmutableStyle
@@ -27,73 +23,7 @@ public abstract class MovingSphereModel implements SceneObject {
     return SceneObjectType.MOVING_SPHERE;
   }
 
-  @Override
-  public Optional<HitRecord> hit(Ray ray, double tMin, double tMax) {
-    Vector3 center = getCenter(ray.getTime());
-    Vector3 oc = ray.getOrigin().subtract(center);
-
-    double a = ray.getDirection().dotProduct(ray.getDirection());
-    double b = oc.dotProduct(ray.getDirection());
-    double c = oc.dotProduct(oc) - (getRadius() * getRadius());
-
-    double discriminant = (b * b) - (a * c);
-
-    if (discriminant > 0) {
-      double negativeTemp = (-b - Math.sqrt(discriminant)) / a; // TODO rename this awful variable
-      Range<Double> parameterRange = Range.open(tMin, tMax);
-
-      if (parameterRange.contains(negativeTemp)) {
-        Vector3 point = ray.getPointAtParameter(negativeTemp);
-        Vector3 normal = point.subtract(center).scalarDivide(getRadius());
-        return Optional.of(
-            HitRecord.builder()
-                .setT(negativeTemp)
-                .setPoint(point)
-                .setNormal(normal)
-                .setMaterial(getMaterial())
-                .build()
-        );
-      }
-
-      double positiveTemp = (-b + Math.sqrt(discriminant)) / a; // TODO rename this awful variable
-      if (parameterRange.contains(positiveTemp)) {
-        Vector3 point = ray.getPointAtParameter(positiveTemp);
-        Vector3 normal = point.subtract(center).scalarDivide(getRadius());
-        return Optional.of(
-            HitRecord.builder()
-                .setT(positiveTemp)
-                .setPoint(point)
-                .setNormal(normal)
-                .setMaterial(getMaterial())
-                .build()
-        );
-      }
-    }
-
-    return Optional.empty();
-  }
-
-  @Override
-  public Optional<AxisAlignedBoundingBox> getBoundingBox(double t0, double t1) {
-    Vector3 radiusVector = Vector3.builder()
-        .setX(getRadius())
-        .setY(getRadius())
-        .setZ(getRadius())
-        .build();
-
-    AxisAlignedBoundingBox box0 = AxisAlignedBoundingBox.builder()
-        .setMin(getCenter(t0).subtract(radiusVector))
-        .setMax(getCenter(t0).add(radiusVector))
-        .build();
-    AxisAlignedBoundingBox box1 = AxisAlignedBoundingBox.builder()
-        .setMin(getCenter(t1).subtract(radiusVector))
-        .setMax(getCenter(t1).add(radiusVector))
-        .build();
-
-    return Optional.of(AxisAlignedBoundingBox.getSurroundingBox(box0, box1));
-  }
-
-  private Vector3 getCenter(double time) {
+  public Vector3 getCenter(double time) {
     double timeMultiplier = (time - getTime0()) / (getTime1() - getTime0());
     return getCenter0().add(getCenter1().subtract(getCenter0()).scalarMultiply(timeMultiplier));
   }

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/ReverseNormalsModel.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/ReverseNormalsModel.java
@@ -1,10 +1,7 @@
 package com.github.nhirakawa.hyperbeam.shape;
 
-import java.util.Optional;
-
 import org.immutables.value.Value;
 
-import com.github.nhirakawa.hyperbeam.geometry.Ray;
 import com.github.nhirakawa.immutable.style.ImmutableStyle;
 
 @Value.Immutable
@@ -12,17 +9,6 @@ import com.github.nhirakawa.immutable.style.ImmutableStyle;
 public abstract class ReverseNormalsModel implements SceneObject {
 
   public abstract SceneObject getSceneObject();
-
-  @Override
-  public Optional<HitRecord> hit(Ray ray, double tMin, double tMax) {
-    return getSceneObject().hit(ray, tMin, tMax)
-        .map(hitRecord -> hitRecord.withNormal(hitRecord.getNormal().negate()));
-  }
-
-  @Override
-  public Optional<AxisAlignedBoundingBox> getBoundingBox(double t0, double t1) {
-    return getSceneObject().getBoundingBox(t0, t1);
-  }
 
   @Override
   public SceneObjectType getShapeType() {

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/SceneObject.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/SceneObject.java
@@ -1,11 +1,8 @@
 package com.github.nhirakawa.hyperbeam.shape;
 
-import java.util.Optional;
-
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
-import com.github.nhirakawa.hyperbeam.geometry.Ray;
 import com.github.nhirakawa.hyperbeam.transform.Translation;
 import com.github.nhirakawa.hyperbeam.transform.YRotation;
 
@@ -29,13 +26,5 @@ public interface SceneObject {
 
   @SuppressWarnings("unused")
   SceneObjectType getShapeType();
-
-  default Optional<HitRecord> hit(Ray ray, double tMin, double tMax) {
-    return Optional.empty();
-  }
-
-  default Optional<AxisAlignedBoundingBox> getBoundingBox(double t0, double t1) {
-    return Optional.empty();
-  }
 
 }

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/SceneObjectsList.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/SceneObjectsList.java
@@ -1,12 +1,10 @@
 package com.github.nhirakawa.hyperbeam.shape;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.github.nhirakawa.hyperbeam.geometry.Ray;
 import com.google.common.collect.ImmutableList;
 
 public class SceneObjectsList implements SceneObject {
@@ -26,48 +24,6 @@ public class SceneObjectsList implements SceneObject {
   @Override
   public SceneObjectType getShapeType() {
     return SceneObjectType.SCENE_OBJECTS_LIST;
-  }
-
-  @Override
-  public Optional<HitRecord> hit(Ray ray, double tMin, double tMax) {
-    Optional<HitRecord> tempRecord = Optional.empty();
-    double closestSoFar = tMax;
-
-    for (int i = 0; i < hittables.size(); i++) {
-      Optional<HitRecord> maybeHitRecord = hittables.get(i).hit(ray, tMin, closestSoFar);
-      if (maybeHitRecord.isPresent()) {
-        tempRecord = maybeHitRecord;
-        closestSoFar = maybeHitRecord.get().getT();
-      }
-    }
-
-    return tempRecord;
-  }
-
-  @Override
-  public Optional<AxisAlignedBoundingBox> getBoundingBox(double t0, double t1) {
-    if (hittables.isEmpty()) {
-      LOG.warn("No hittables");
-      return Optional.empty();
-    }
-
-    Optional<AxisAlignedBoundingBox> current = hittables.get(0).getBoundingBox(t0, t1);
-    if (!current.isPresent()) {
-      LOG.warn("Could not get box for first hittable");
-      return Optional.empty();
-    }
-
-    for (int i = 0; i < hittables.size(); i++) {
-      Optional<AxisAlignedBoundingBox> temp = hittables.get(i).getBoundingBox(t0, t1);
-      if (!temp.isPresent()) {
-        LOG.warn("No bounding box for {}", hittables.get(i));
-        return Optional.empty();
-      }
-
-      current = Optional.of(AxisAlignedBoundingBox.getSurroundingBox(current.get(), temp.get()));
-    }
-
-    return current;
   }
 
 }

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/SphereModel.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/SphereModel.java
@@ -1,15 +1,11 @@
 package com.github.nhirakawa.hyperbeam.shape;
 
-import java.util.Optional;
-
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.github.nhirakawa.hyperbeam.geometry.Ray;
 import com.github.nhirakawa.hyperbeam.geometry.Vector3;
 import com.github.nhirakawa.hyperbeam.material.Material;
 import com.github.nhirakawa.immutable.style.ImmutableStyle;
-import com.google.common.collect.Range;
 
 @Value.Immutable
 @ImmutableStyle
@@ -42,78 +38,6 @@ public abstract class SphereModel implements SceneObject {
   @Value.Auxiliary
   public SceneObjectType getShapeType() {
     return SceneObjectType.SPHERE;
-  }
-
-  @Override
-  public Optional<HitRecord> hit(Ray ray, double tMin, double tMax) {
-    Vector3 oc = ray.getOrigin().subtract(getCenter());
-
-    double a = ray.getDirection().dotProduct(ray.getDirection());
-    double b = oc.dotProduct(ray.getDirection());
-    double c = oc.dotProduct(oc) - (getRadius() * getRadius());
-
-    double discriminant = (b * b) - (a * c);
-
-    if (discriminant > 0) {
-      double negativeTemp = (-b - Math.sqrt(discriminant)) / a; // TODO rename this awful variable
-      Range<Double> parameterRange = Range.open(tMin, tMax);
-
-      if (parameterRange.contains(negativeTemp)) {
-        Vector3 point = ray.getPointAtParameter(negativeTemp);
-        Vector3 normal = point.subtract(getCenter()).scalarDivide(getRadius());
-
-        Vector3 uvPoint = point.subtract(getCenter());
-
-        double phi = Math.atan2(uvPoint.getZ(), uvPoint.getX());
-        double theta = Math.asin(uvPoint.getY());
-
-        double u = (1 - phi + Math.PI) / (2 * Math.PI);
-        double v = (theta + (Math.PI / 2)) / Math.PI;
-
-        return Optional.of(
-            HitRecord.builder()
-                .setT(negativeTemp)
-                .setPoint(point)
-                .setNormal(normal)
-                .setMaterial(getMaterial())
-                .setU(u)
-                .setV(v)
-                .build()
-        );
-      }
-
-      double positiveTemp = (-b + Math.sqrt(discriminant)) / a; // TODO rename this awful variable
-      if (parameterRange.contains(positiveTemp)) {
-        Vector3 point = ray.getPointAtParameter(positiveTemp);
-        Vector3 normal = point.subtract(getCenter()).scalarDivide(getRadius());
-
-        Vector3 uvPpoint = point.subtract(getCenter());
-
-        double phi = Math.atan2(uvPpoint.getZ(), uvPpoint.getX());
-        double theta = Math.asin(uvPpoint.getY());
-
-        double u = (1 - phi + Math.PI) / (2 * Math.PI);
-        double v = (theta + (Math.PI / 2)) / Math.PI;
-
-        return Optional.of(
-            HitRecord.builder()
-                .setT(positiveTemp)
-                .setPoint(point)
-                .setNormal(normal)
-                .setMaterial(getMaterial())
-                .setU(u)
-                .setV(v)
-                .build()
-        );
-      }
-    }
-
-    return Optional.empty();
-  }
-
-  @Override
-  public Optional<AxisAlignedBoundingBox> getBoundingBox(double t0, double t1) {
-    return Optional.of(getAxisAlignedBoundingBox());
   }
 
 }

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/XYRectangleModel.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/XYRectangleModel.java
@@ -5,7 +5,6 @@ import java.util.Optional;
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.github.nhirakawa.hyperbeam.geometry.Ray;
 import com.github.nhirakawa.hyperbeam.geometry.Vector3;
 import com.github.nhirakawa.hyperbeam.material.Material;
 import com.github.nhirakawa.immutable.style.ImmutableStyle;
@@ -48,47 +47,6 @@ public abstract class XYRectangleModel implements SceneObject {
   @Value.Auxiliary
   public SceneObjectType getShapeType() {
     return SceneObjectType.XY_RECTANGLE;
-  }
-
-  @Override
-  public Optional<HitRecord> hit(Ray ray, double tMin, double tMax) {
-    double t = (getK() - ray.getOrigin().getZ()) / ray.getDirection().getZ();
-
-    if (t < tMin || t > tMax) {
-      return Optional.empty();
-    }
-
-    double x = ray.getOrigin().getX() + (ray.getDirection().getX() * t);
-    double y = ray.getOrigin().getY() + (ray.getDirection().getY() * t);
-
-    if (x < getX0() || x > getX1() || y < getY0() || y > getY1()) {
-      return Optional.empty();
-    }
-
-    double u = (x - getX0()) / (getX1() - getX0());
-    double v = (y - getY0()) / (getY1() - getY0());
-
-    Vector3 normal = Vector3.builder()
-        .setX(0)
-        .setY(0)
-        .setZ(1)
-        .build();
-
-    return Optional.of(
-        HitRecord.builder()
-            .setPoint(ray.getPointAtParameter(t))
-            .setNormal(normal)
-            .setMaterial(getMaterial())
-            .setT(t)
-            .setU(u)
-            .setV(v)
-            .build()
-    );
-  }
-
-  @Override
-  public Optional<AxisAlignedBoundingBox> getBoundingBox(double t0, double t1) {
-    return getBoundingBox();
   }
 
 }

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/XZRectangleModel.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/XZRectangleModel.java
@@ -1,11 +1,8 @@
 package com.github.nhirakawa.hyperbeam.shape;
 
-import java.util.Optional;
-
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.github.nhirakawa.hyperbeam.geometry.Ray;
 import com.github.nhirakawa.hyperbeam.geometry.Vector3;
 import com.github.nhirakawa.hyperbeam.material.Material;
 import com.github.nhirakawa.immutable.style.ImmutableStyle;
@@ -52,41 +49,6 @@ public abstract class XZRectangleModel implements SceneObject {
   @JsonIgnore
   public Vector3 getNormal() {
     return NORMAL;
-  }
-
-  @Override
-  public Optional<HitRecord> hit(Ray ray, double tMin, double tMax) {
-    double t = (getK() - ray.getOrigin().getY()) / ray.getDirection().getY();
-
-    if (t < tMin || t > tMax) {
-      return Optional.empty();
-    }
-
-    double x = ray.getOrigin().getX() + (t * ray.getDirection().getX());
-    double z = ray.getOrigin().getZ() + (t * ray.getDirection().getZ());
-
-    if (x < getX0() || x > getX1() || z < getZ0() || z > getZ1()) {
-      return Optional.empty();
-    }
-
-    double u = (x - getX0()) / (getX1() - getX0());
-    double v = (z - getZ0()) / (getZ1() - getZ0());
-
-    return Optional.of(
-        HitRecord.builder()
-            .setPoint(ray.getPointAtParameter(t))
-            .setT(t)
-            .setU(u)
-            .setV(v)
-            .setNormal(getNormal())
-            .setMaterial(getMaterial())
-            .build()
-    );
-  }
-
-  @Override
-  public Optional<AxisAlignedBoundingBox> getBoundingBox(double t0, double t1) {
-    return Optional.of(getBoundingBox());
   }
 
   @Override

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/YZRectangleModel.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/YZRectangleModel.java
@@ -1,11 +1,8 @@
 package com.github.nhirakawa.hyperbeam.shape;
 
-import java.util.Optional;
-
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.github.nhirakawa.hyperbeam.geometry.Ray;
 import com.github.nhirakawa.hyperbeam.geometry.Vector3;
 import com.github.nhirakawa.hyperbeam.material.Material;
 import com.github.nhirakawa.immutable.style.ImmutableStyle;
@@ -52,41 +49,6 @@ public abstract class YZRectangleModel implements SceneObject {
         .setMin(min)
         .setMax(max)
         .build();
-  }
-
-  @Override
-  public Optional<HitRecord> hit(Ray ray, double tMin, double tMax) {
-    double t = (getK() - ray.getOrigin().getX()) / ray.getDirection().getX();
-
-    if (t < tMin || t > tMax) {
-      return Optional.empty();
-    }
-
-    double y = ray.getOrigin().getY() + (t * ray.getDirection().getY());
-    double z = ray.getOrigin().getZ() + (t * ray.getDirection().getZ());
-
-    if (y < getY0() || y > getY1() || z < getZ0() || z > getZ1()) {
-      return Optional.empty();
-    }
-
-    double u = (y - getY0()) / (getY1() - getY0());
-    double v = (z - getZ0()) / (getZ1() - getZ0());
-
-    return Optional.of(
-        HitRecord.builder()
-            .setPoint(ray.getPointAtParameter(t))
-            .setMaterial(getMaterial())
-            .setT(t)
-            .setU(u)
-            .setV(v)
-            .setNormal(getNormal())
-            .build()
-    );
-  }
-
-  @Override
-  public Optional<AxisAlignedBoundingBox> getBoundingBox(double t0, double t1) {
-    return Optional.of(getBoundingBox());
   }
 
   @Override

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/transform/TranslationModel.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/transform/TranslationModel.java
@@ -1,13 +1,9 @@
 package com.github.nhirakawa.hyperbeam.transform;
 
-import java.util.Optional;
-
 import org.immutables.value.Value;
 
-import com.github.nhirakawa.hyperbeam.geometry.Ray;
 import com.github.nhirakawa.hyperbeam.geometry.Vector3;
 import com.github.nhirakawa.hyperbeam.shape.AxisAlignedBoundingBox;
-import com.github.nhirakawa.hyperbeam.shape.HitRecord;
 import com.github.nhirakawa.hyperbeam.shape.SceneObject;
 import com.github.nhirakawa.hyperbeam.shape.SceneObjectType;
 import com.github.nhirakawa.immutable.style.ImmutableStyle;
@@ -20,26 +16,12 @@ public abstract class TranslationModel implements SceneObject {
   public abstract Vector3 getOffset();
 
   @Override
-  public Optional<HitRecord> hit(Ray ray, double tMin, double tMax) {
-    Ray offsetRay = ray.withOrigin(ray.getOrigin().subtract(getOffset()));
-
-    return getSceneObject().hit(offsetRay, tMin, tMax)
-        .map(hitRecord -> hitRecord.withPoint(hitRecord.getPoint().add(getOffset())));
-  }
-
-  @Override
-  public Optional<AxisAlignedBoundingBox> getBoundingBox(double t0, double t1) {
-    return getSceneObject().getBoundingBox(t0, t1)
-        .map(this::getOffsetAxisAlignedBoundingBox);
-  }
-
-  @Override
   @Value.Auxiliary
   public SceneObjectType getShapeType() {
     return SceneObjectType.TRANSLATION;
   }
 
-  private AxisAlignedBoundingBox getOffsetAxisAlignedBoundingBox(AxisAlignedBoundingBox axisAlignedBoundingBox) {
+  public AxisAlignedBoundingBox getOffsetAxisAlignedBoundingBox(AxisAlignedBoundingBox axisAlignedBoundingBox) {
     Vector3 offsetMin = axisAlignedBoundingBox.getMin().add(getOffset());
     Vector3 offsetMax = axisAlignedBoundingBox.getMax().add(getOffset());
 
@@ -48,5 +30,4 @@ public abstract class TranslationModel implements SceneObject {
         .setMax(offsetMax)
         .build();
   }
-
 }

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/transform/YRotationModel.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/transform/YRotationModel.java
@@ -1,22 +1,11 @@
 package com.github.nhirakawa.hyperbeam.transform;
 
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.github.nhirakawa.hyperbeam.geometry.Ray;
-import com.github.nhirakawa.hyperbeam.geometry.Vector3;
-import com.github.nhirakawa.hyperbeam.shape.AxisAlignedBoundingBox;
-import com.github.nhirakawa.hyperbeam.shape.HitRecord;
 import com.github.nhirakawa.hyperbeam.shape.SceneObject;
 import com.github.nhirakawa.hyperbeam.shape.SceneObjectType;
 import com.github.nhirakawa.immutable.style.ImmutableStyle;
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 
 @ImmutableStyle
 @Value.Immutable
@@ -41,141 +30,6 @@ public abstract class YRotationModel implements SceneObject {
   @JsonIgnore
   public double getCosTheta() {
     return Math.cos(getAngleInRadians());
-  }
-
-  @Value.Derived
-  @JsonIgnore
-  public Optional<AxisAlignedBoundingBox> getBoundingBox() {
-    Optional<AxisAlignedBoundingBox> maybeBoundingBox = getSceneObject().getBoundingBox(0, 1);
-    if (!maybeBoundingBox.isPresent()) {
-      return Optional.empty();
-    }
-
-    AxisAlignedBoundingBox boundingBox = maybeBoundingBox.get();
-
-    Vector3 min = Vector3.max();
-    Vector3 max = Vector3.min();
-
-    Set<Integer> integers = ImmutableSet.of(0, 1);
-    Set<List<Integer>> products = Sets.cartesianProduct(integers, integers, integers);
-
-    for (List<Integer> product : products) {
-      Preconditions.checkState(product.size() == 3);
-
-      int i = product.get(0);
-      int j = product.get(1);
-      int k = product.get(2);
-
-      double x = (i * boundingBox.getMax().getX()) + ((1 - i) * boundingBox.getMin().getX());
-      double y = (j * boundingBox.getMax().getY()) + ((1 - j) * boundingBox.getMin().getY());
-      double z = (k * boundingBox.getMax().getZ()) + ((1 - k) * boundingBox.getMin().getZ());
-
-      double newX = (getCosTheta() * x) + (getSinTheta() * z);
-      double newZ = (getCosTheta() * z) - (getSinTheta() * x);
-
-      Vector3 tester = Vector3.builder()
-          .setX(newX)
-          .setY(y)
-          .setZ(newZ)
-          .build();
-
-      double maxX = Math.max(tester.getX(), max.getX());
-      double maxY = Math.max(tester.getY(), max.getY());
-      double maxZ = Math.max(tester.getZ(), max.getZ());
-
-      max = Vector3.builder()
-          .setX(maxX)
-          .setY(maxY)
-          .setZ(maxZ)
-          .build();
-
-      double minX = Math.min(tester.getX(), min.getX());
-      double minY = Math.min(tester.getY(), min.getY());
-      double minZ = Math.min(tester.getZ(), min.getZ());
-
-      min = Vector3.builder()
-          .setX(minX)
-          .setY(minY)
-          .setZ(minZ)
-          .build();
-    }
-
-    return Optional.of(
-        AxisAlignedBoundingBox.builder()
-            .setMin(min)
-            .setMax(max)
-            .build()
-    );
-  }
-
-  @Override
-  public Optional<HitRecord> hit(Ray ray, double tMin, double tMax) {
-    Vector3 origin = ray.getOrigin();
-    Vector3 direction = ray.getDirection();
-
-    double newOriginX = (getCosTheta() * origin.getX()) - (getSinTheta() * origin.getZ());
-    double newOriginZ = (getSinTheta() * origin.getX()) + (getCosTheta() * origin.getZ());
-
-    double newDirectionX = (getCosTheta() * direction.getX()) - (getSinTheta() * direction.getZ());
-    double newDirectionZ = (getSinTheta() * direction.getX()) + (getCosTheta() * direction.getZ());
-
-    Vector3 newOrigin = Vector3.builder()
-        .setX(newOriginX)
-        .setY(origin.getY())
-        .setZ(newOriginZ)
-        .build();
-
-    Vector3 newDirection = Vector3.builder()
-        .setX(newDirectionX)
-        .setY(direction.getY())
-        .setZ(newDirectionZ)
-        .build();
-
-    Ray rotatedRay = Ray.builder()
-        .from(ray)
-        .setOrigin(newOrigin)
-        .setDirection(newDirection)
-        .build();
-
-    Optional<HitRecord> maybeHitRecord = getSceneObject().hit(rotatedRay, tMin, tMax);
-    if (!maybeHitRecord.isPresent()) {
-      return Optional.empty();
-    }
-
-    HitRecord hitRecord = maybeHitRecord.get();
-    Vector3 point = hitRecord.getPoint();
-    Vector3 normal = hitRecord.getNormal();
-
-    double newPointX = (getCosTheta() * point.getX()) + (getSinTheta() * point.getZ());
-    double newPointZ = (getCosTheta() * point.getZ()) - (getSinTheta() * point.getX());
-
-    double newNormalX = (getCosTheta() * normal.getX()) + (getSinTheta() * normal.getZ());
-    double newNormalZ = (getCosTheta() * normal.getZ()) - (getSinTheta() * normal.getZ());
-
-    Vector3 newPoint = Vector3.builder()
-        .setX(newPointX)
-        .setY(point.getY())
-        .setZ(newPointZ)
-        .build();
-
-    Vector3 newNormal = Vector3.builder()
-        .setX(newNormalX)
-        .setY(normal.getY())
-        .setZ(newNormalZ)
-        .build();
-
-    return Optional.of(
-        HitRecord.builder()
-            .from(hitRecord)
-            .setPoint(newPoint)
-            .setNormal(newNormal)
-            .build()
-    );
-  }
-
-  @Override
-  public Optional<AxisAlignedBoundingBox> getBoundingBox(double t0, double t1) {
-    return getBoundingBox();
   }
 
   @Override

--- a/hyperbeam-core/src/main/resources/reference.conf
+++ b/hyperbeam-core/src/main/resources/reference.conf
@@ -3,8 +3,8 @@
     samples = 100
 
     dimensions {
-      rows = 800
-      columns = 400
+      rows = 400
+      columns = 200
       multiplier = 1
     }
 

--- a/hyperbeam-single-machine/src/main/java/com/github/nhirakawa/hyperbeam/HyperbeamModule.java
+++ b/hyperbeam-single-machine/src/main/java/com/github/nhirakawa/hyperbeam/HyperbeamModule.java
@@ -34,9 +34,23 @@ class HyperbeamModule {
 
   @Provides
   @Singleton
+  static RayProcessor provideRayProcessor() {
+    return new RayProcessor();
+  }
+
+  @Provides
+  @Singleton
+  static SortedHittablesFactory provideSortedHittablesFactory(RayProcessor rayProcessor) {
+    return new SortedHittablesFactory(rayProcessor);
+  }
+
+  @Provides
+  @Singleton
   static RayTracer provideRayTracer(ObjectMapper objectMapper,
-                                    ConfigWrapper configWrapper) {
-    return new RayTracer(objectMapper, configWrapper);
+                                    ConfigWrapper configWrapper,
+                                    RayProcessor rayProcessor,
+                                    SortedHittablesFactory sortedHittablesFactory) {
+    return new RayTracer(objectMapper, configWrapper, rayProcessor, sortedHittablesFactory);
   }
 
 }


### PR DESCRIPTION
Moves all of the actual logic outside of the models and into a centralized class (for metrics and logging). Eventually these will be algebraic data types, but `instanceof` is ok for now.