### PR TITLE
Algebraic data types

### DIFF
--- a/hyperbeam-core/pom.xml
+++ b/hyperbeam-core/pom.xml
@@ -47,6 +47,11 @@
       <artifactId>metrics-core</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.derive4j</groupId>
+      <artifactId>derive4j</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/AlgebraicSceneObject.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/AlgebraicSceneObject.java
@@ -1,0 +1,38 @@
+package com.github.nhirakawa.hyperbeam;
+
+import org.derive4j.Data;
+
+import com.github.nhirakawa.hyperbeam.shape.BoundingVolumeHierarchyModel;
+import com.github.nhirakawa.hyperbeam.shape.BoxModel;
+import com.github.nhirakawa.hyperbeam.shape.ConstantMediumModel;
+import com.github.nhirakawa.hyperbeam.shape.MovingSphereModel;
+import com.github.nhirakawa.hyperbeam.shape.ReverseNormalsModel;
+import com.github.nhirakawa.hyperbeam.shape.SceneObjectsList;
+import com.github.nhirakawa.hyperbeam.shape.SphereModel;
+import com.github.nhirakawa.hyperbeam.shape.XYRectangleModel;
+import com.github.nhirakawa.hyperbeam.shape.XZRectangleModel;
+import com.github.nhirakawa.hyperbeam.shape.YZRectangleModel;
+import com.github.nhirakawa.hyperbeam.transform.TranslationModel;
+import com.github.nhirakawa.hyperbeam.transform.YRotationModel;
+
+@Data
+public abstract class AlgebraicSceneObject {
+
+  interface Cases<R> {
+    R BOUNDING_VOLUME_HIERARCHY(BoundingVolumeHierarchyModel boundingVolumeHierarchy);
+    R BOX(BoxModel box);
+    R CONSTANT_MEDIUM(ConstantMediumModel constantMedium);
+    R MOVING_SPHERE(MovingSphereModel movingSphere);
+    R REVERSE_NORMALS(ReverseNormalsModel reverseNormals);
+    R SCENE_OBJECTS_LIST(SceneObjectsList sceneObjectsList);
+    R SPHERE(SphereModel sphere);
+    R TRANSLATION(TranslationModel translation);
+    R XY_RECTANGLE(XYRectangleModel xyRectangle);
+    R XZ_RECTANGLE(XZRectangleModel xzRectangle);
+    R Y_ROTATION(YRotationModel yRotation);
+    R YZ_RECTANGLE(YZRectangleModel yzRectangle);
+  }
+
+  public abstract <R> R match(Cases<R> cases);
+
+}

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/RayProcessor.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/RayProcessor.java
@@ -15,7 +15,6 @@ import com.github.nhirakawa.hyperbeam.shape.ConstantMediumModel;
 import com.github.nhirakawa.hyperbeam.shape.HitRecord;
 import com.github.nhirakawa.hyperbeam.shape.MovingSphereModel;
 import com.github.nhirakawa.hyperbeam.shape.ReverseNormalsModel;
-import com.github.nhirakawa.hyperbeam.shape.SceneObject;
 import com.github.nhirakawa.hyperbeam.shape.SceneObjectsList;
 import com.github.nhirakawa.hyperbeam.shape.SphereModel;
 import com.github.nhirakawa.hyperbeam.shape.XYRectangleModel;
@@ -32,56 +31,21 @@ public class RayProcessor {
 
   // hit record
 
-  public Optional<HitRecord> hit(SceneObject sceneObject, Ray ray, double tMin, double tMax) {
-    if (sceneObject instanceof SphereModel) {
-      return hitSphere((SphereModel) sceneObject, ray, tMin, tMax);
-    }
-
-    if (sceneObject instanceof BoundingVolumeHierarchyModel) {
-      return hitBoundingVolumeHierarchy((BoundingVolumeHierarchyModel) sceneObject, ray, tMin, tMax);
-    }
-
-    if (sceneObject instanceof BoxModel) {
-      return hitBox((BoxModel) sceneObject, ray, tMin, tMax);
-    }
-
-    if (sceneObject instanceof SceneObjectsList) {
-      return hitSceneObjectsList((SceneObjectsList) sceneObject, ray, tMin, tMax);
-    }
-
-    if (sceneObject instanceof ConstantMediumModel) {
-      return hitConstantMedium((ConstantMediumModel) sceneObject, ray, tMin, tMax);
-    }
-
-    if (sceneObject instanceof MovingSphereModel) {
-      return hitMovingSphere((MovingSphereModel) sceneObject, ray, tMin, tMax);
-    }
-
-    if (sceneObject instanceof ReverseNormalsModel) {
-      return hitReverseNormals((ReverseNormalsModel) sceneObject, ray, tMin, tMax);
-    }
-
-    if (sceneObject instanceof XYRectangleModel) {
-      return hitXYRectantle((XYRectangleModel) sceneObject, ray, tMin, tMax);
-    }
-
-    if (sceneObject instanceof XZRectangleModel) {
-      return hitXZRectangle((XZRectangleModel) sceneObject, ray, tMin, tMax);
-    }
-
-    if (sceneObject instanceof YZRectangleModel) {
-      return hitYZRectangle((YZRectangleModel) sceneObject, ray, tMin, tMax);
-    }
-
-    if (sceneObject instanceof TranslationModel) {
-      return hitTranslation((TranslationModel) sceneObject, ray, tMin, tMax);
-    }
-
-    if (sceneObject instanceof YRotationModel) {
-      return hitYRotation((YRotationModel) sceneObject, ray, tMin, tMax);
-    }
-
-    throw new IllegalArgumentException("Can't hit unknown object - " + sceneObject);
+  public Optional<HitRecord> hit(AlgebraicSceneObject sceneObject, Ray ray, double tMin, double tMax) {
+    return AlgebraicSceneObjects.cases()
+        .BOUNDING_VOLUME_HIERARCHY(boundingVolumeHierarchyModel -> hitBoundingVolumeHierarchy(boundingVolumeHierarchyModel, ray, tMin, tMax))
+        .BOX(box -> hitBox(box, ray, tMin, tMax))
+        .CONSTANT_MEDIUM(constantMediumModel -> hitConstantMedium(constantMediumModel, ray, tMin, tMax))
+        .MOVING_SPHERE(movingSphereModel -> hitMovingSphere(movingSphereModel, ray, tMin, tMax))
+        .REVERSE_NORMALS(reverseNormalsModel -> hitReverseNormals(reverseNormalsModel, ray, tMin, tMax))
+        .SCENE_OBJECTS_LIST(sceneObjectsList -> hitSceneObjectsList(sceneObjectsList, ray, tMin, tMax))
+        .SPHERE(sphereModel -> hitSphere(sphereModel, ray, tMin, tMax))
+        .TRANSLATION(translationModel -> hitTranslation(translationModel, ray, tMin, tMax))
+        .XY_RECTANGLE(xyRectangleModel -> hitXYRectantle(xyRectangleModel, ray, tMin, tMax))
+        .XZ_RECTANGLE(xzRectangleModel -> hitXZRectangle(xzRectangleModel, ray, tMin, tMax))
+        .Y_ROTATION(yRotationModel -> hitYRotation(yRotationModel, ray, tMin, tMax))
+        .YZ_RECTANGLE(yzRectangleModel -> hitYZRectangle(yzRectangleModel, ray, tMin, tMax))
+        .apply(sceneObject);
   }
 
   private Optional<HitRecord> hitSphere(SphereModel sphere, Ray ray, double tMin, double tMax) {
@@ -174,7 +138,8 @@ public class RayProcessor {
   }
 
   private Optional<HitRecord> hitBox(BoxModel box, Ray ray, double tMin, double tMax) {
-    return hit(box.getSceneObjectsList(), ray, tMin, tMax);
+    AlgebraicSceneObject sceneObjectsList = AlgebraicSceneObjects.SCENE_OBJECTS_LIST(box.getSceneObjectsList());
+    return hit(sceneObjectsList, ray, tMin, tMax);
   }
 
   private Optional<HitRecord> hitSceneObjectsList(SceneObjectsList sceneObjectsList, Ray ray, double tMin, double tMax) {
@@ -457,56 +422,20 @@ public class RayProcessor {
 
   // bounding box
 
-  public Optional<AxisAlignedBoundingBox> getBoundingBox(SceneObject sceneObject, double t0, double t1) {
-    if (sceneObject instanceof BoundingVolumeHierarchyModel) {
-      return getBoundingBoxForBoundingVolumeHierarcy((BoundingVolumeHierarchyModel) sceneObject, t0, t1);
-    }
-
-    if (sceneObject instanceof BoxModel) {
-      return getBoundingBoxForBox((BoxModel) sceneObject, t0, t1);
-    }
-
-    if (sceneObject instanceof ConstantMediumModel) {
-      return getBoundingBoxForConstantMedium((ConstantMediumModel) sceneObject, t0, t1);
-    }
-
-    if (sceneObject instanceof MovingSphereModel) {
-      return getBoundingBoxForMovingSphere((MovingSphereModel) sceneObject, t0, t1);
-    }
-
-    if (sceneObject instanceof ReverseNormalsModel) {
-      return getBoundingBoxForReverseNormals((ReverseNormalsModel) sceneObject, t0, t1);
-    }
-
-    if (sceneObject instanceof SceneObjectsList) {
-      return getBoundingBoxForSceneObjectsList((SceneObjectsList) sceneObject, t0, t1);
-    }
-
-    if (sceneObject instanceof SphereModel) {
-      return getBoundingBoxForSphere((SphereModel) sceneObject, t0, t1);
-    }
-
-    if (sceneObject instanceof XYRectangleModel) {
-      return getBoundingBoxForXYRectangle((XYRectangleModel) sceneObject, t0, t1);
-    }
-
-    if (sceneObject instanceof XZRectangleModel) {
-      return getBoundingBoxForXZRectangle((XZRectangleModel) sceneObject, t0, t1);
-    }
-
-    if (sceneObject instanceof YZRectangleModel) {
-      return getBoundingBoxForYZRectangle((YZRectangleModel) sceneObject, t0, t1);
-    }
-
-    if (sceneObject instanceof TranslationModel) {
-      return getBoundingBoxForTranslation((TranslationModel) sceneObject, t0, t1);
-    }
-
-    if (sceneObject instanceof YRotationModel) {
-      return getBoundingBoxForYRotation((YRotationModel) sceneObject, t0, t1);
-    }
-
-    throw new IllegalArgumentException("Cannot get bounding box for " + sceneObject);
+  public Optional<AxisAlignedBoundingBox> getBoundingBox(AlgebraicSceneObject sceneObject, double t0, double t1) {
+    return AlgebraicSceneObjects.caseOf(sceneObject)
+        .BOUNDING_VOLUME_HIERARCHY(boundingVolumeHierarchyModel -> getBoundingBoxForBoundingVolumeHierarcy(boundingVolumeHierarchyModel, t0, t1))
+        .BOX(boxModel -> getBoundingBoxForBox(boxModel, t0, t1))
+        .CONSTANT_MEDIUM(constantMediumModel -> getBoundingBoxForConstantMedium(constantMediumModel, t0, t1))
+        .MOVING_SPHERE(movingSphereModel -> getBoundingBoxForMovingSphere(movingSphereModel, t0, t1))
+        .REVERSE_NORMALS(reverseNormalsModel -> getBoundingBoxForReverseNormals(reverseNormalsModel, t0, t1))
+        .SCENE_OBJECTS_LIST(sceneObjectsList -> getBoundingBoxForSceneObjectsList(sceneObjectsList, t0, t1))
+        .SPHERE(sphereModel -> getBoundingBoxForSphere(sphereModel, t0, t1))
+        .TRANSLATION(translationModel -> getBoundingBoxForTranslation(translationModel, t0, t1))
+        .XY_RECTANGLE(xyRectangleModel -> getBoundingBoxForXYRectangle(xyRectangleModel, t0, t1))
+        .XZ_RECTANGLE(xzRectangleModel -> getBoundingBoxForXZRectangle(xzRectangleModel, t0, t1))
+        .Y_ROTATION(yRotationModel -> getBoundingBoxForYRotation(yRotationModel, t0, t1))
+        .YZ_RECTANGLE(yzRectangleModel -> getBoundingBoxForYZRectangle(yzRectangleModel, t0, t1));
   }
 
   private Optional<AxisAlignedBoundingBox> getBoundingBoxForBoundingVolumeHierarcy(BoundingVolumeHierarchyModel boundingVolumeHierarchy, double t0, double t1) {
@@ -514,7 +443,7 @@ public class RayProcessor {
   }
 
   private AxisAlignedBoundingBox getAxisAlignedBoundingBoxForBoundingVolumeHierarchy(BoundingVolumeHierarchyModel boundingVolumeHierarchy) {
-    Optional<AxisAlignedBoundingBox> leftBox =getBoundingBox(boundingVolumeHierarchy.getLeft(), boundingVolumeHierarchy.getTime0(), boundingVolumeHierarchy.getTime1());
+    Optional<AxisAlignedBoundingBox> leftBox = getBoundingBox(boundingVolumeHierarchy.getLeft(), boundingVolumeHierarchy.getTime0(), boundingVolumeHierarchy.getTime1());
     Optional<AxisAlignedBoundingBox> rightBox = getBoundingBox(boundingVolumeHierarchy.getRight(), boundingVolumeHierarchy.getTime0(), boundingVolumeHierarchy.getTime1());
 
     Preconditions.checkState(leftBox.isPresent(), "Could not get bounding box for %s", boundingVolumeHierarchy.getLeft());

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/SortedHittablesFactory.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/SortedHittablesFactory.java
@@ -7,7 +7,6 @@ import java.util.Optional;
 import java.util.function.Function;
 
 import com.github.nhirakawa.hyperbeam.shape.AxisAlignedBoundingBox;
-import com.github.nhirakawa.hyperbeam.shape.SceneObject;
 import com.github.nhirakawa.hyperbeam.util.MathUtils;
 import com.google.common.collect.ImmutableList;
 
@@ -23,8 +22,8 @@ public class SortedHittablesFactory {
   private static final Function<AxisAlignedBoundingBox, Double> MIN_Y = aabb -> aabb.getMin().getY();
   private static final Function<AxisAlignedBoundingBox, Double> MIN_Z = aabb -> aabb.getMin().getZ();
 
-  List<SceneObject> getSortedHittables(Collection<SceneObject> sceneObjects) {
-    final Comparator<SceneObject> comparator;
+  List<AlgebraicSceneObject> getSortedHittables(Collection<AlgebraicSceneObject> sceneObjects) {
+    final Comparator<AlgebraicSceneObject> comparator;
     switch ((int) (MathUtils.rand() * 3)) {
       case 0:
         comparator = getComparator(MIN_X);
@@ -44,7 +43,7 @@ public class SortedHittablesFactory {
         .collect(ImmutableList.toImmutableList());
   }
 
-  private Comparator<SceneObject> getComparator(Function<AxisAlignedBoundingBox, Double> function) {
+  private Comparator<AlgebraicSceneObject> getComparator(Function<AxisAlignedBoundingBox, Double> function) {
     return (hittable1, hittable2) -> {
       Optional<AxisAlignedBoundingBox> box1 = rayProcessor.getBoundingBox(hittable1, 0, 0);
       Optional<AxisAlignedBoundingBox> box2 = rayProcessor.getBoundingBox(hittable2, 0, 0);

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/scene/SceneGenerator.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/scene/SceneGenerator.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.guava.GuavaModule;
+import com.github.nhirakawa.hyperbeam.AlgebraicSceneObjects;
 import com.github.nhirakawa.hyperbeam.camera.Camera;
 import com.github.nhirakawa.hyperbeam.geometry.Vector3;
 import com.github.nhirakawa.hyperbeam.material.DiffuseLightMaterial;
@@ -301,14 +302,16 @@ public final class SceneGenerator {
     List<SceneObject> sceneObjects = ImmutableList.of(
         ReverseNormals.builder()
             .setSceneObject(
-                YZRectangle.builder()
-                    .setY0(0)
-                    .setY1(555)
-                    .setZ0(0)
-                    .setZ1(555)
-                    .setK(555)
-                    .setMaterial(green)
-                    .build()
+                AlgebraicSceneObjects.YZ_RECTANGLE(
+                    YZRectangle.builder()
+                        .setY0(0)
+                        .setY1(555)
+                        .setZ0(0)
+                        .setZ1(555)
+                        .setK(555)
+                        .setMaterial(green)
+                        .build()
+                )
             )
             .build(),
         YZRectangle.builder()
@@ -329,14 +332,16 @@ public final class SceneGenerator {
             .build(),
         ReverseNormals.builder()
             .setSceneObject(
-                XZRectangle.builder()
-                    .setX0(0)
-                    .setX1(555)
-                    .setZ0(0)
-                    .setZ1(555)
-                    .setK(555)
-                    .setMaterial(white)
-                    .build()
+                AlgebraicSceneObjects.XZ_RECTANGLE(
+                    XZRectangle.builder()
+                        .setX0(0)
+                        .setX1(555)
+                        .setZ0(0)
+                        .setZ1(555)
+                        .setK(555)
+                        .setMaterial(white)
+                        .build()
+                )
             )
             .build(),
         XZRectangle.builder()
@@ -349,34 +354,40 @@ public final class SceneGenerator {
             .build(),
         ReverseNormals.builder()
             .setSceneObject(
-                XYRectangle.builder()
-                    .setX0(0)
-                    .setX1(555)
-                    .setY0(0)
-                    .setY1(555)
-                    .setK(555)
-                    .setMaterial(white)
-                    .build()
+                AlgebraicSceneObjects.XY_RECTANGLE(
+                    XYRectangle.builder()
+                        .setX0(0)
+                        .setX1(555)
+                        .setY0(0)
+                        .setY1(555)
+                        .setK(555)
+                        .setMaterial(white)
+                        .build()
+                )
             )
             .build(),
         Translation.builder()
             .setSceneObject(
-                YRotation.builder()
-                    .setSceneObject(
-                        Box.builder()
-                            .setPMin(Vector3.zero())
-                            .setPMax(
-                                Vector3.builder()
-                                    .setX(165)
-                                    .setY(165)
-                                    .setZ(165)
+                AlgebraicSceneObjects.Y_ROTATION(
+                    YRotation.builder()
+                        .setSceneObject(
+                            AlgebraicSceneObjects.BOX(
+                                Box.builder()
+                                    .setPMin(Vector3.zero())
+                                    .setPMax(
+                                        Vector3.builder()
+                                            .setX(165)
+                                            .setY(165)
+                                            .setZ(165)
+                                            .build()
+                                    )
+                                    .setMaterial(white)
                                     .build()
                             )
-                            .setMaterial(white)
-                            .build()
-                    )
-                    .setAngleInDegrees(-18)
-                    .build()
+                        )
+                        .setAngleInDegrees(-18)
+                        .build()
+                )
             )
             .setOffset(
                 Vector3.builder()
@@ -388,22 +399,26 @@ public final class SceneGenerator {
             .build(),
         Translation.builder()
             .setSceneObject(
-                YRotation.builder()
-                    .setSceneObject(
-                        Box.builder()
-                            .setPMin(Vector3.zero())
-                            .setPMax(
-                                Vector3.builder()
-                                    .setX(165)
-                                    .setY(330)
-                                    .setZ(165)
+                AlgebraicSceneObjects.Y_ROTATION(
+                    YRotation.builder()
+                        .setSceneObject(
+                            AlgebraicSceneObjects.BOX(
+                                Box.builder()
+                                    .setPMin(Vector3.zero())
+                                    .setPMax(
+                                        Vector3.builder()
+                                            .setX(165)
+                                            .setY(330)
+                                            .setZ(165)
+                                            .build()
+                                    )
+                                    .setMaterial(white)
                                     .build()
                             )
-                            .setMaterial(white)
-                            .build()
-                    )
-                    .setAngleInDegrees(15)
-                    .build()
+                        )
+                        .setAngleInDegrees(15)
+                        .build()
+                )
             )
             .setOffset(
                 Vector3.builder()
@@ -508,14 +523,16 @@ public final class SceneGenerator {
     List<SceneObject> sceneObjects = ImmutableList.of(
         ReverseNormals.builder()
             .setSceneObject(
-                YZRectangle.builder()
-                    .setY0(0)
-                    .setY1(555)
-                    .setZ0(0)
-                    .setZ1(555)
-                    .setK(555)
-                    .setMaterial(green)
-                    .build()
+                AlgebraicSceneObjects.YZ_RECTANGLE(
+                    YZRectangle.builder()
+                        .setY0(0)
+                        .setY1(555)
+                        .setZ0(0)
+                        .setZ1(555)
+                        .setK(555)
+                        .setMaterial(green)
+                        .build()
+                )
             )
             .build(),
         YZRectangle.builder()
@@ -536,14 +553,16 @@ public final class SceneGenerator {
             .build(),
         ReverseNormals.builder()
             .setSceneObject(
-                XZRectangle.builder()
-                    .setX0(0)
-                    .setX1(555)
-                    .setZ0(0)
-                    .setZ1(555)
-                    .setK(555)
-                    .setMaterial(white)
-                    .build()
+                AlgebraicSceneObjects.XZ_RECTANGLE(
+                    XZRectangle.builder()
+                        .setX0(0)
+                        .setX1(555)
+                        .setZ0(0)
+                        .setZ1(555)
+                        .setK(555)
+                        .setMaterial(white)
+                        .build()
+                )
             )
             .build(),
         XZRectangle.builder()
@@ -556,45 +575,53 @@ public final class SceneGenerator {
             .build(),
         ReverseNormals.builder()
             .setSceneObject(
-                XYRectangle.builder()
-                    .setX0(0)
-                    .setX1(555)
-                    .setY0(0)
-                    .setY1(555)
-                    .setK(555)
-                    .setMaterial(white)
-                    .build()
+                AlgebraicSceneObjects.XY_RECTANGLE(
+                    XYRectangle.builder()
+                        .setX0(0)
+                        .setX1(555)
+                        .setY0(0)
+                        .setY1(555)
+                        .setK(555)
+                        .setMaterial(white)
+                        .build()
+                )
             )
             .build(),
         ConstantMedium.builder()
             .setSceneObject(
-                Translation.builder()
-                    .setSceneObject(
-                        YRotation.builder()
-                            .setSceneObject(
-                                Box.builder()
-                                    .setPMin(Vector3.zero())
-                                    .setPMax(
-                                        Vector3.builder()
-                                            .setX(165)
-                                            .setY(165)
-                                            .setZ(165)
-                                            .build()
+                AlgebraicSceneObjects.TRANSLATION(
+                    Translation.builder()
+                        .setSceneObject(
+                            AlgebraicSceneObjects.Y_ROTATION(
+                                YRotation.builder()
+                                    .setSceneObject(
+                                        AlgebraicSceneObjects.BOX(
+                                            Box.builder()
+                                                .setPMin(Vector3.zero())
+                                                .setPMax(
+                                                    Vector3.builder()
+                                                        .setX(165)
+                                                        .setY(165)
+                                                        .setZ(165)
+                                                        .build()
+                                                )
+                                                .setMaterial(white)
+                                                .build()
+                                        )
                                     )
-                                    .setMaterial(white)
+                                    .setAngleInDegrees(-18)
                                     .build()
                             )
-                            .setAngleInDegrees(-18)
-                            .build()
-                    )
-                    .setOffset(
-                        Vector3.builder()
-                            .setX(130)
-                            .setY(0)
-                            .setZ(65)
-                            .build()
-                    )
-                    .build()
+                        )
+                        .setOffset(
+                            Vector3.builder()
+                                .setX(130)
+                                .setY(0)
+                                .setZ(65)
+                                .build()
+                        )
+                        .build()
+                )
             )
             .setDensity(0.01)
             .setTexture(
@@ -605,33 +632,39 @@ public final class SceneGenerator {
             .build(),
         ConstantMedium.builder()
             .setSceneObject(
-                Translation.builder()
-                    .setSceneObject(
-                        YRotation.builder()
-                            .setSceneObject(
-                                Box.builder()
-                                    .setPMin(Vector3.zero())
-                                    .setPMax(
-                                        Vector3.builder()
-                                            .setX(165)
-                                            .setY(330)
-                                            .setZ(165)
-                                            .build()
+                AlgebraicSceneObjects.TRANSLATION(
+                    Translation.builder()
+                        .setSceneObject(
+                            AlgebraicSceneObjects.Y_ROTATION(
+                                YRotation.builder()
+                                    .setSceneObject(
+                                        AlgebraicSceneObjects.BOX(
+                                            Box.builder()
+                                                .setPMin(Vector3.zero())
+                                                .setPMax(
+                                                    Vector3.builder()
+                                                        .setX(165)
+                                                        .setY(330)
+                                                        .setZ(165)
+                                                        .build()
+                                                )
+                                                .setMaterial(white)
+                                                .build()
+                                        )
                                     )
-                                    .setMaterial(white)
+                                    .setAngleInDegrees(15)
                                     .build()
                             )
-                            .setAngleInDegrees(15)
-                            .build()
-                    )
-                    .setOffset(
-                        Vector3.builder()
-                            .setX(265)
-                            .setY(0)
-                            .setZ(295)
-                            .build()
-                    )
-                    .build()
+                        )
+                        .setOffset(
+                            Vector3.builder()
+                                .setX(265)
+                                .setY(0)
+                                .setZ(295)
+                                .build()
+                        )
+                        .build()
+                )
             )
             .setDensity(0.01)
             .setTexture(

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/BoundingVolumeHierarchyModel.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/BoundingVolumeHierarchyModel.java
@@ -5,13 +5,15 @@ import java.util.List;
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.github.nhirakawa.hyperbeam.AlgebraicSceneObject;
+import com.github.nhirakawa.hyperbeam.AlgebraicSceneObjects;
 import com.github.nhirakawa.immutable.style.ImmutableStyle;
 
 @Value.Immutable
 @ImmutableStyle
 public abstract class BoundingVolumeHierarchyModel implements SceneObject {
 
-  public abstract List<SceneObject> getSortedSceneObjects();
+  public abstract List<AlgebraicSceneObject> getSortedSceneObjects();
   public abstract double getTime0();
   public abstract double getTime1();
 
@@ -21,10 +23,17 @@ public abstract class BoundingVolumeHierarchyModel implements SceneObject {
     return SceneObjectType.BOUNDING_VOLUME_HIERARCHY;
   }
 
+  @Override
   @Value.Lazy
   @JsonIgnore
-  public SceneObject getLeft() {
-    List<SceneObject> sortedHittablesList = getSortedSceneObjects();
+  public AlgebraicSceneObject toAlgebraicSceneObject() {
+    return AlgebraicSceneObjects.BOUNDING_VOLUME_HIERARCHY(this);
+  }
+
+  @Value.Lazy
+  @JsonIgnore
+  public AlgebraicSceneObject getLeft() {
+    List<AlgebraicSceneObject> sortedHittablesList = getSortedSceneObjects();
     int size = sortedHittablesList.size();
 
     if (size == 1) {
@@ -32,18 +41,20 @@ public abstract class BoundingVolumeHierarchyModel implements SceneObject {
     } else if (size == 2) {
       return sortedHittablesList.get(0);
     } else {
-      return BoundingVolumeHierarchy.builder()
-          .setSortedSceneObjects(sortedHittablesList.subList(0, size / 2))
-          .setTime0(getTime0())
-          .setTime1(getTime1())
-          .build();
+      return AlgebraicSceneObjects.BOUNDING_VOLUME_HIERARCHY(
+          BoundingVolumeHierarchy.builder()
+              .setSortedSceneObjects(sortedHittablesList.subList(0, size / 2))
+              .setTime0(getTime0())
+              .setTime1(getTime1())
+              .build()
+      );
     }
   }
 
   @Value.Lazy
   @JsonIgnore
-  public SceneObject getRight() {
-    List<SceneObject> sortedHittablesList = getSortedSceneObjects();
+  public AlgebraicSceneObject getRight() {
+    List<AlgebraicSceneObject> sortedHittablesList = getSortedSceneObjects();
     int size = sortedHittablesList.size();
 
     if (size == 1) {
@@ -51,11 +62,13 @@ public abstract class BoundingVolumeHierarchyModel implements SceneObject {
     } else if (size == 2) {
       return sortedHittablesList.get(1);
     } else {
-      return BoundingVolumeHierarchy.builder()
-          .setSortedSceneObjects(sortedHittablesList.subList(size / 2, size))
-          .setTime0(getTime0())
-          .setTime1(getTime1())
-          .build();
+      return AlgebraicSceneObjects.BOUNDING_VOLUME_HIERARCHY(
+          BoundingVolumeHierarchy.builder()
+              .setSortedSceneObjects(sortedHittablesList.subList(size / 2, size))
+              .setTime0(getTime0())
+              .setTime1(getTime1())
+              .build()
+      );
     }
   }
 

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/BoxModel.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/BoxModel.java
@@ -3,6 +3,8 @@ package com.github.nhirakawa.hyperbeam.shape;
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.github.nhirakawa.hyperbeam.AlgebraicSceneObject;
+import com.github.nhirakawa.hyperbeam.AlgebraicSceneObjects;
 import com.github.nhirakawa.hyperbeam.geometry.Vector3;
 import com.github.nhirakawa.hyperbeam.material.Material;
 import com.github.nhirakawa.immutable.style.ImmutableStyle;
@@ -16,71 +18,96 @@ public abstract class BoxModel implements SceneObject {
   public abstract Vector3 getPMax();
   public abstract Material getMaterial();
 
+  @Override
+  @JsonIgnore
+  @Value.Lazy
+  public AlgebraicSceneObject toAlgebraicSceneObject() {
+    return AlgebraicSceneObjects.BOX(this);
+  }
+
   @Value.Lazy
   @JsonIgnore
   public SceneObjectsList getSceneObjectsList() {
     return new SceneObjectsList(
         ImmutableList.of(
-            XYRectangle.builder() // 0
-                .setX0(getPMin().getX())
-                .setX1(getPMax().getX())
-                .setY0(getPMin().getY())
-                .setY1(getPMax().getY())
-                .setK(getPMax().getZ())
-                .setMaterial(getMaterial())
-                .build(),
-            ReverseNormals.builder() // 1
-                .setSceneObject(
-                    XYRectangle.builder()
-                        .setX0(getPMin().getX())
-                        .setX1(getPMax().getX())
-                        .setY0(getPMin().getY())
-                        .setY1(getPMax().getY())
-                        .setK(getPMin().getZ())
-                        .setMaterial(getMaterial())
-                        .build()
-                )
-                .build(),
-            XZRectangle.builder() // 2
-                .setX0(getPMin().getX())
-                .setX1(getPMax().getX())
-                .setZ0(getPMin().getZ())
-                .setZ1(getPMax().getZ())
-                .setK(getPMax().getY())
-                .setMaterial(getMaterial())
-                .build(),
-            ReverseNormals.builder() // 3
-                .setSceneObject(
-                    XZRectangle.builder()
-                        .setX0(getPMin().getX())
-                        .setX1(getPMax().getX())
-                        .setZ0(getPMin().getZ())
-                        .setZ1(getPMax().getZ())
-                        .setK(getPMin().getY())
-                        .setMaterial(getMaterial())
-                        .build()
-                )
-                .build(),
-            YZRectangle.builder() // 4
-                .setY0(getPMin().getY())
-                .setY1(getPMax().getY())
-                .setZ0(getPMin().getZ())
-                .setZ1(getPMax().getZ())
-                .setK(getPMax().getX())
-                .setMaterial(getMaterial())
-                .build(),
-            ReverseNormals.builder() // 5
-                .setSceneObject(
-                    YZRectangle.builder()
-                        .setY0(getPMin().getY())
-                        .setY1(getPMax().getY())
-                        .setZ0(getPMin().getZ())
-                        .setZ1(getPMax().getZ())
-                        .setK(getPMin().getX())
-                        .setMaterial(getMaterial())
-                        .build()
-                )
-                .build()
+            AlgebraicSceneObjects.XY_RECTANGLE(
+                XYRectangle.builder() // 0
+                    .setX0(getPMin().getX())
+                    .setX1(getPMax().getX())
+                    .setY0(getPMin().getY())
+                    .setY1(getPMax().getY())
+                    .setK(getPMax().getZ())
+                    .setMaterial(getMaterial())
+                    .build()
+            ),
+            AlgebraicSceneObjects.REVERSE_NORMALS(
+                ReverseNormals.builder() // 1
+                    .setSceneObject(
+                        AlgebraicSceneObjects.XY_RECTANGLE(
+                            XYRectangle.builder()
+                                .setX0(getPMin().getX())
+                                .setX1(getPMax().getX())
+                                .setY0(getPMin().getY())
+                                .setY1(getPMax().getY())
+                                .setK(getPMin().getZ())
+                                .setMaterial(getMaterial())
+                                .build()
+                        )
+                    )
+                    .build()
+            ),
+            AlgebraicSceneObjects.XZ_RECTANGLE(
+                XZRectangle.builder() // 2
+                    .setX0(getPMin().getX())
+                    .setX1(getPMax().getX())
+                    .setZ0(getPMin().getZ())
+                    .setZ1(getPMax().getZ())
+                    .setK(getPMax().getY())
+                    .setMaterial(getMaterial())
+                    .build()
+            ),
+            AlgebraicSceneObjects.REVERSE_NORMALS(
+                ReverseNormals.builder() // 3
+                    .setSceneObject(
+                        AlgebraicSceneObjects.XZ_RECTANGLE(
+                            XZRectangle.builder()
+                                .setX0(getPMin().getX())
+                                .setX1(getPMax().getX())
+                                .setZ0(getPMin().getZ())
+                                .setZ1(getPMax().getZ())
+                                .setK(getPMin().getY())
+                                .setMaterial(getMaterial())
+                                .build()
+                        )
+                    )
+                    .build()
+            ),
+            AlgebraicSceneObjects.YZ_RECTANGLE(
+                YZRectangle.builder() // 4
+                    .setY0(getPMin().getY())
+                    .setY1(getPMax().getY())
+                    .setZ0(getPMin().getZ())
+                    .setZ1(getPMax().getZ())
+                    .setK(getPMax().getX())
+                    .setMaterial(getMaterial())
+                    .build()
+            ),
+            AlgebraicSceneObjects.REVERSE_NORMALS(
+                ReverseNormals.builder() // 5
+                    .setSceneObject(
+                        AlgebraicSceneObjects.YZ_RECTANGLE(
+                            YZRectangle.builder()
+                                .setY0(getPMin().getY())
+                                .setY1(getPMax().getY())
+                                .setZ0(getPMin().getZ())
+                                .setZ1(getPMax().getZ())
+                                .setK(getPMin().getX())
+                                .setMaterial(getMaterial())
+                                .build()
+                        )
+                    )
+                    .build()
+            )
         )
     );
   }

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/ConstantMediumModel.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/ConstantMediumModel.java
@@ -3,6 +3,8 @@ package com.github.nhirakawa.hyperbeam.shape;
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.github.nhirakawa.hyperbeam.AlgebraicSceneObject;
+import com.github.nhirakawa.hyperbeam.AlgebraicSceneObjects;
 import com.github.nhirakawa.hyperbeam.geometry.Vector3;
 import com.github.nhirakawa.hyperbeam.material.IsotropicMaterial;
 import com.github.nhirakawa.hyperbeam.material.Material;
@@ -19,9 +21,16 @@ public abstract class ConstantMediumModel implements SceneObject {
       .setZ(0)
       .build();
 
-  public abstract SceneObject getSceneObject();
+  public abstract AlgebraicSceneObject getSceneObject();
   public abstract double getDensity();
   public abstract Texture getTexture();
+
+  @Override
+  @Value.Lazy
+  @JsonIgnore
+  public AlgebraicSceneObject toAlgebraicSceneObject() {
+    return AlgebraicSceneObjects.CONSTANT_MEDIUM(this);
+  }
 
   @Value.Derived
   @JsonIgnore

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/MovingSphereModel.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/MovingSphereModel.java
@@ -2,6 +2,9 @@ package com.github.nhirakawa.hyperbeam.shape;
 
 import org.immutables.value.Value;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.github.nhirakawa.hyperbeam.AlgebraicSceneObject;
+import com.github.nhirakawa.hyperbeam.AlgebraicSceneObjects;
 import com.github.nhirakawa.hyperbeam.geometry.Vector3;
 import com.github.nhirakawa.hyperbeam.material.Material;
 import com.github.nhirakawa.immutable.style.ImmutableStyle;
@@ -21,6 +24,13 @@ public abstract class MovingSphereModel implements SceneObject {
   @Value.Auxiliary
   public SceneObjectType getShapeType() {
     return SceneObjectType.MOVING_SPHERE;
+  }
+
+  @Override
+  @Value.Lazy
+  @JsonIgnore
+  public AlgebraicSceneObject toAlgebraicSceneObject() {
+    return AlgebraicSceneObjects.MOVING_SPHERE(this);
   }
 
   public Vector3 getCenter(double time) {

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/ReverseNormalsModel.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/ReverseNormalsModel.java
@@ -2,17 +2,27 @@ package com.github.nhirakawa.hyperbeam.shape;
 
 import org.immutables.value.Value;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.github.nhirakawa.hyperbeam.AlgebraicSceneObject;
+import com.github.nhirakawa.hyperbeam.AlgebraicSceneObjects;
 import com.github.nhirakawa.immutable.style.ImmutableStyle;
 
 @Value.Immutable
 @ImmutableStyle
 public abstract class ReverseNormalsModel implements SceneObject {
 
-  public abstract SceneObject getSceneObject();
+  public abstract AlgebraicSceneObject getSceneObject();
 
   @Override
   public SceneObjectType getShapeType() {
     return SceneObjectType.REVERSE_NORMALS;
+  }
+
+  @Override
+  @Value.Lazy
+  @JsonIgnore
+  public AlgebraicSceneObject toAlgebraicSceneObject() {
+    return AlgebraicSceneObjects.REVERSE_NORMALS(this);
   }
 
 }

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/SceneObject.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/SceneObject.java
@@ -3,6 +3,7 @@ package com.github.nhirakawa.hyperbeam.shape;
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.github.nhirakawa.hyperbeam.AlgebraicSceneObject;
 import com.github.nhirakawa.hyperbeam.transform.Translation;
 import com.github.nhirakawa.hyperbeam.transform.YRotation;
 
@@ -26,5 +27,7 @@ public interface SceneObject {
 
   @SuppressWarnings("unused")
   SceneObjectType getShapeType();
+
+  AlgebraicSceneObject toAlgebraicSceneObject();
 
 }

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/SceneObjectsList.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/SceneObjectsList.java
@@ -2,28 +2,30 @@ package com.github.nhirakawa.hyperbeam.shape;
 
 import java.util.List;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
+import com.github.nhirakawa.hyperbeam.AlgebraicSceneObject;
+import com.github.nhirakawa.hyperbeam.AlgebraicSceneObjects;
 import com.google.common.collect.ImmutableList;
 
 public class SceneObjectsList implements SceneObject {
 
-  private static final Logger LOG = LoggerFactory.getLogger(SceneObjectsList.class);
+  private final List<AlgebraicSceneObject> hittables;
 
-  private final List<? extends SceneObject> hittables;
-
-  public SceneObjectsList(List<? extends SceneObject> hittables) {
+  public SceneObjectsList(List<AlgebraicSceneObject> hittables) {
     this.hittables = ImmutableList.copyOf(hittables);
   }
 
-  public List<? extends SceneObject> getHittables() {
+  public List<AlgebraicSceneObject> getHittables() {
     return hittables;
   }
 
   @Override
   public SceneObjectType getShapeType() {
     return SceneObjectType.SCENE_OBJECTS_LIST;
+  }
+
+  @Override
+  public AlgebraicSceneObject toAlgebraicSceneObject() {
+    return AlgebraicSceneObjects.SCENE_OBJECTS_LIST(this);
   }
 
 }

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/SphereModel.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/SphereModel.java
@@ -3,6 +3,8 @@ package com.github.nhirakawa.hyperbeam.shape;
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.github.nhirakawa.hyperbeam.AlgebraicSceneObject;
+import com.github.nhirakawa.hyperbeam.AlgebraicSceneObjects;
 import com.github.nhirakawa.hyperbeam.geometry.Vector3;
 import com.github.nhirakawa.hyperbeam.material.Material;
 import com.github.nhirakawa.immutable.style.ImmutableStyle;
@@ -38,6 +40,13 @@ public abstract class SphereModel implements SceneObject {
   @Value.Auxiliary
   public SceneObjectType getShapeType() {
     return SceneObjectType.SPHERE;
+  }
+
+  @Override
+  @JsonIgnore
+  @Value.Lazy
+  public AlgebraicSceneObject toAlgebraicSceneObject() {
+    return AlgebraicSceneObjects.SPHERE(this);
   }
 
 }

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/XYRectangleModel.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/XYRectangleModel.java
@@ -5,6 +5,8 @@ import java.util.Optional;
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.github.nhirakawa.hyperbeam.AlgebraicSceneObject;
+import com.github.nhirakawa.hyperbeam.AlgebraicSceneObjects;
 import com.github.nhirakawa.hyperbeam.geometry.Vector3;
 import com.github.nhirakawa.hyperbeam.material.Material;
 import com.github.nhirakawa.immutable.style.ImmutableStyle;
@@ -47,6 +49,13 @@ public abstract class XYRectangleModel implements SceneObject {
   @Value.Auxiliary
   public SceneObjectType getShapeType() {
     return SceneObjectType.XY_RECTANGLE;
+  }
+
+  @Override
+  @JsonIgnore
+  @Value.Lazy
+  public AlgebraicSceneObject toAlgebraicSceneObject() {
+    return AlgebraicSceneObjects.XY_RECTANGLE(this);
   }
 
 }

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/XZRectangleModel.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/XZRectangleModel.java
@@ -3,6 +3,8 @@ package com.github.nhirakawa.hyperbeam.shape;
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.github.nhirakawa.hyperbeam.AlgebraicSceneObject;
+import com.github.nhirakawa.hyperbeam.AlgebraicSceneObjects;
 import com.github.nhirakawa.hyperbeam.geometry.Vector3;
 import com.github.nhirakawa.hyperbeam.material.Material;
 import com.github.nhirakawa.immutable.style.ImmutableStyle;
@@ -55,6 +57,13 @@ public abstract class XZRectangleModel implements SceneObject {
   @Value.Auxiliary
   public SceneObjectType getShapeType() {
     return SceneObjectType.XZ_RECTANGLE;
+  }
+
+  @Override
+  @Value.Lazy
+  @JsonIgnore
+  public AlgebraicSceneObject toAlgebraicSceneObject() {
+    return AlgebraicSceneObjects.XZ_RECTANGLE(this);
   }
 
 }

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/YZRectangleModel.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/shape/YZRectangleModel.java
@@ -3,6 +3,8 @@ package com.github.nhirakawa.hyperbeam.shape;
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.github.nhirakawa.hyperbeam.AlgebraicSceneObject;
+import com.github.nhirakawa.hyperbeam.AlgebraicSceneObjects;
 import com.github.nhirakawa.hyperbeam.geometry.Vector3;
 import com.github.nhirakawa.hyperbeam.material.Material;
 import com.github.nhirakawa.immutable.style.ImmutableStyle;
@@ -55,6 +57,13 @@ public abstract class YZRectangleModel implements SceneObject {
   @Value.Auxiliary
   public SceneObjectType getShapeType() {
     return SceneObjectType.YZ_RECTANGLE;
+  }
+
+  @Override
+  @JsonIgnore
+  @Value.Lazy
+  public AlgebraicSceneObject toAlgebraicSceneObject() {
+    return AlgebraicSceneObjects.YZ_RECTANGLE(this);
   }
 
 }

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/transform/TranslationModel.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/transform/TranslationModel.java
@@ -2,6 +2,9 @@ package com.github.nhirakawa.hyperbeam.transform;
 
 import org.immutables.value.Value;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.github.nhirakawa.hyperbeam.AlgebraicSceneObject;
+import com.github.nhirakawa.hyperbeam.AlgebraicSceneObjects;
 import com.github.nhirakawa.hyperbeam.geometry.Vector3;
 import com.github.nhirakawa.hyperbeam.shape.AxisAlignedBoundingBox;
 import com.github.nhirakawa.hyperbeam.shape.SceneObject;
@@ -12,13 +15,20 @@ import com.github.nhirakawa.immutable.style.ImmutableStyle;
 @ImmutableStyle
 public abstract class TranslationModel implements SceneObject {
 
-  public abstract SceneObject getSceneObject();
+  public abstract AlgebraicSceneObject getSceneObject();
   public abstract Vector3 getOffset();
 
   @Override
   @Value.Auxiliary
   public SceneObjectType getShapeType() {
     return SceneObjectType.TRANSLATION;
+  }
+
+  @Override
+  @JsonIgnore
+  @Value.Lazy
+  public AlgebraicSceneObject toAlgebraicSceneObject() {
+    return AlgebraicSceneObjects.TRANSLATION(this);
   }
 
   public AxisAlignedBoundingBox getOffsetAxisAlignedBoundingBox(AxisAlignedBoundingBox axisAlignedBoundingBox) {

--- a/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/transform/YRotationModel.java
+++ b/hyperbeam-core/src/main/java/com/github/nhirakawa/hyperbeam/transform/YRotationModel.java
@@ -3,6 +3,8 @@ package com.github.nhirakawa.hyperbeam.transform;
 import org.immutables.value.Value;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.github.nhirakawa.hyperbeam.AlgebraicSceneObject;
+import com.github.nhirakawa.hyperbeam.AlgebraicSceneObjects;
 import com.github.nhirakawa.hyperbeam.shape.SceneObject;
 import com.github.nhirakawa.hyperbeam.shape.SceneObjectType;
 import com.github.nhirakawa.immutable.style.ImmutableStyle;
@@ -11,7 +13,7 @@ import com.github.nhirakawa.immutable.style.ImmutableStyle;
 @Value.Immutable
 public abstract class YRotationModel implements SceneObject {
 
-  public abstract SceneObject getSceneObject();
+  public abstract AlgebraicSceneObject getSceneObject();
   public abstract double getAngleInDegrees();
 
   @Value.Derived
@@ -36,6 +38,13 @@ public abstract class YRotationModel implements SceneObject {
   @Value.Auxiliary
   public SceneObjectType getShapeType() {
     return SceneObjectType.Y_ROTATION;
+  }
+
+  @Override
+  @JsonIgnore
+  @Value.Lazy
+  public AlgebraicSceneObject toAlgebraicSceneObject() {
+    return AlgebraicSceneObjects.Y_ROTATION(this);
   }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <assertj-core.version>3.11.1</assertj-core.version>
     <config.version>1.3.2</config.version>
     <dagger.version>2.19</dagger.version>
+    <derive4j.version>1.1.0</derive4j.version>
     <dockerfile.maven.version>1.4.10</dockerfile.maven.version>
     <dockerfile.useMavenSettingsForAuth>true</dockerfile.useMavenSettingsForAuth>
     <error_prone_annotations.version>2.1.3</error_prone_annotations.version>
@@ -106,6 +107,11 @@
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>${assertj-core.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.derive4j</groupId>
+        <artifactId>derive4j</artifactId>
+        <version>${derive4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.immutables</groupId>


### PR DESCRIPTION
This PR gets rid of `instanceof` checks in favor of algebraic data types. Interestingly, render times increased (for cornell box) from~77 seconds to ~300 seconds. The `instanceof` is ugly, but the performance penalty is undesirable. I might add logging to see if there's a way to cache computations somewhere.